### PR TITLE
Alert message was hidden behind top bar, fixed it

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,5 @@
-html, body {
+html,
+body {
   height: 100%;
   margin: 0;
   font-family: var(--font-family-roboto);
@@ -28,14 +29,14 @@ html, body {
 }
 
 :root {
-  --color-indigo-dye: #003E6B;
-  --color-blue-munsell: #1E8B9B;
-  --color-papaya-whip: #FFEFD8;
-  --color-butterscotch: #E38B3A;
-  --color-rust: #A83A15;
+  --color-indigo-dye: #003e6b;
+  --color-blue-munsell: #1e8b9b;
+  --color-papaya-whip: #ffefd8;
+  --color-butterscotch: #e38b3a;
+  --color-rust: #a83a15;
   --color-rust-light: #e7836f;
 
-  --font-family-roboto: 'Roboto', Arial, sans-serif;
+  --font-family-roboto: "Roboto", Arial, sans-serif;
   --font-h1-size: 32px;
   --font-h1-weight: 700;
   --font-h2-size: 24px;
@@ -51,14 +52,16 @@ html, body {
   --font-footer-text: 12px;
 }
 
-.navbar, .navbar .container-fluid {
+.navbar,
+.navbar .container-fluid {
   padding-left: 0 !important;
   padding-right: 0 !important;
   margin: 0 !important;
   min-height: 56px;
 }
 
-.btn, .dropdown-toggle {
+.btn,
+.dropdown-toggle {
   box-sizing: border-box;
 }
 
@@ -75,7 +78,7 @@ html, body {
 
 .btn-primary {
   background: var(--color-indigo-dye);
-  color: #FFF;
+  color: #fff;
   border: none;
 }
 .btn-primary:hover {
@@ -100,11 +103,11 @@ html, body {
 }
 .btn-warning:hover {
   background: var(--color-rust);
-  color: #FFF;
+  color: #fff;
 }
 
 .input-txt {
-  background: #FFF;
+  background: #fff;
   border: 2px solid var(--color-indigo-dye);
   border-radius: 20px;
   padding: 10px;
@@ -122,7 +125,7 @@ html, body {
 }
 
 .txt {
-  background: #FFF;
+  background: #fff;
   border: 2px solid var(--color-blue-munsell);
   border-radius: 20px;
   padding: 10px;
@@ -140,7 +143,7 @@ html, body {
 }
 
 .ddl {
-  background: #FFF;
+  background: #fff;
   border: 2px solid var(--color-blue-munsell);
   border-radius: 20px;
   color: var(--color-indigo-dye);
@@ -154,11 +157,11 @@ html, body {
 }
 .ddl option {
   color: var(--color-indigo-dye);
-  background: #FFF;
+  background: #fff;
 }
 
 .lst {
-  background: #FFF;
+  background: #fff;
   color: var(--color-indigo-dye);
   font-size: 16px;
   border: 2px solid var(--color-blue-munsell);
@@ -169,7 +172,7 @@ html, body {
 .lst option:checked,
 .lst option[selected] {
   background: var(--color-blue-munsell);
-  color: #FFF;
+  color: #fff;
 }
 
 .chk {
@@ -177,7 +180,7 @@ html, body {
   height: 16px;
   border-radius: 2px;
   border: 1px solid #565d6dff;
-  background: #FFF;
+  background: #fff;
   appearance: none;
   cursor: pointer;
   position: relative;
@@ -187,7 +190,7 @@ html, body {
   border-color: var(--color-blue-munsell);
 }
 .chk:checked::after {
-  content: '';
+  content: "";
   display: block;
   position: absolute;
   left: 4px;
@@ -200,14 +203,14 @@ html, body {
   border-color: var(--color-blue-munsell);
 }
 .chk:indeterminate::after {
-  content: '';
+  content: "";
   display: block;
   position: absolute;
   left: 3px;
   top: 7px;
   width: 10px;
   height: 2px;
-  background: #FFF;
+  background: #fff;
 }
 .chk:disabled {
   opacity: 0.4;
@@ -215,7 +218,7 @@ html, body {
 }
 
 .card {
-  background: #FFF;
+  background: #fff;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 20px;
@@ -233,12 +236,11 @@ html, body {
   color: var(--color-indigo-dye);
 }
 .card-header {
-  background-color: #FFF;
+  background-color: #fff;
   color: var(--color-indigo-dye);
   border-radius: 12px 12px 0 0;
   padding: 16px 20px;
 }
-
 
 .form-group {
   display: flex;
@@ -255,13 +257,13 @@ html, body {
 }
 .form-control[required]::after,
 .required-asterisk {
-  content: '*';
-  color: #A83A15;
+  content: "*";
+  color: #a83a15;
   margin-left: 4px;
 }
 .form-control.normal {
   border: 2px solid var(--color-blue-munsell);
-  background: #FFF;
+  background: #fff;
 }
 .form-control:focus {
   border: 3px solid var(--color-indigo-dye);
@@ -271,7 +273,7 @@ html, body {
   border: 2px solid var(--color-rust);
 }
 .form-control:disabled {
-  background: #F0F0F0;
+  background: #f0f0f0;
   color: #888;
   cursor: not-allowed;
 }
@@ -347,4 +349,9 @@ html, body {
 .input-filter {
   max-width: 400px;
   width: 100%;
+}
+
+.cdk-overlay-container {
+  position: fixed;
+  z-index: 1300;
 }


### PR DESCRIPTION
## Description of the Change

- Alert messages were hidden behind the topbar due to the z-index. Added a higher z-index for the alerts so they appear on top of the topbar.
---

## What Was Done?

- [ ] Added a higher z-index for the alerts so they appear on top of the topbar.

---

## How to Test It

1. Add, delete or edit something. 

---

## Related Issues

N/A
