### PR TITLE
Feature/materials

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -25,6 +25,7 @@ import { GroupStudentsComponent } from "./pages/groupstudents/students.component
 import { AssignmentsComponent } from "./pages/assignments/assignments.component";
 import { QuizzesComponent } from "./pages/quizzes/quizzes.component";
 import { ChatComponent } from "./pages/chat/chat.component";
+import {MaterialsComponent} from "./pages/materials/materials.component";
 
 export const routes: Routes = [
   {
@@ -210,6 +211,16 @@ export const routes: Routes = [
             IRoleType.student,
           ],
           name: "Chat",
+          showInSidebar: false,
+        },
+      },
+      {
+        path: "materials",
+        component: MaterialsComponent,
+        canActivate: [AdminTeacherRoleGuard],
+        data: {
+          authorities: [IRoleType.superAdmin, IRoleType.teacher],
+          name: "Materiales",
           showInSidebar: false,
         },
       },

--- a/src/app/components/courses/course-list/courses-list.component.html
+++ b/src/app/components/courses/course-list/courses-list.component.html
@@ -1,100 +1,110 @@
 <div class="card">
-  <div class="card-header card-header-indigo">
-    <h2 class="mb-0">Lista de Cursos</h2>
-  </div>
-  <div class="card-body">
-    <p class="text-muted mb-3">
-      Si deseas ver o agregar historias para una escuela, selecciona su título
-      en la tabla.
-    </p>
-    <div class="mb-4 mt-2">
-      <input
-        type="text"
-        class="input-txt w-25"
-        placeholder="Filtrar cursos por código o título..."
-        [(ngModel)]="searchText"
-      />
+    <div class="card-header card-header-indigo">
+        <h2 class="mb-0">Lista de Cursos</h2>
     </div>
+    <div class="card-body">
+        <p class="text-muted mb-3">
+            Si deseas ver o agregar historias para una escuela, selecciona su título
+            en la tabla.
+        </p>
+        <div class="mb-4 mt-2">
+            <input
+                    type="text"
+                    class="input-txt w-25"
+                    placeholder="Filtrar cursos por código o título..."
+                    [(ngModel)]="searchText"
+            />
+        </div>
 
-    <div class="table-container table-responsive">
-      <table class="table custom-full-bordered-table">
-        <thead class="table-header-gray">
-          <tr>
-            <th scope="col">Título</th>
-            <th scope="col">Código</th>
-            <th scope="col">Descripción</th>
-            <th scope="col">Fecha de creación</th>
-            <th class="text-center" scope="col">Acciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          @for (item of filteredCourses; track item.code) {
-          <tr>
-            <td>
-              <a
-                [routerLink]="['/app/stories']"
-                [queryParams]="{ courseId: item.id }"
-                class="no-link-style"
-              >
-                {{ item.title }}
-              </a>
-            </td>
-            <td>{{ item.code }}</td>
-            <td>{{ item.description }}</td>
-            <td>{{ item.createdAt | date : "dd/MM/yyyy HH:mm" }}</td>
-            <td class="text-center">
-              <button
-                [disabled]="item.code === 'DEFAULT'"
-                [attr.title]="
+        <div class="table-container table-responsive">
+            <table class="table custom-full-bordered-table">
+                <thead class="table-header-gray">
+                <tr>
+                    <th scope="col">Título</th>
+                    <th scope="col">Código</th>
+                    <th scope="col">Descripción</th>
+                    <th scope="col">Fecha de creación</th>
+                    <th class="text-center" scope="col">Acciones</th>
+                </tr>
+                </thead>
+                <tbody>
+                    @for (item of filteredCourses; track item.code) {
+                        <tr>
+                            <td>
+                                <div class="d-flex flex-column">
+                                    <a
+                                            [routerLink]="['/app/stories']"
+                                            [queryParams]="{ courseId: item.id }"
+                                            class="no-link-style mb-1"
+                                    >
+                                        {{ item.title }}
+                                    </a>
+                                    <a
+                                            [routerLink]="['/app/materials']"
+                                            [queryParams]="{ courseId: item.id }"
+                                            class="no-link-style text-link-special d-flex align-items-center"
+                                    >
+                                        <i class="fas fa-folder-open me-2"></i> Ver materiales
+                                    </a>
+                                </div>
+                            </td>
+                            <td>{{ item.code }}</td>
+                            <td>{{ item.description }}</td>
+                            <td>{{ item.createdAt | date : "dd/MM/yyyy HH:mm" }}</td>
+                            <td class="text-center">
+                                <button
+                                        [disabled]="item.code === 'DEFAULT'"
+                                        [attr.title]="
                   item.code === 'DEFAULT'
                     ? 'Este curso no se puede editar'
                     : null
                 "
-                (click)="callModalAction.emit(item)"
-                class="btn border-0 me-2 icon-gray-color"
-                type="button"
-              >
-                <i class="fas fa-pen"></i>
-              </button>
-              <button
-                [disabled]="item.code === 'DEFAULT'"
-                [attr.title]="
+                                        (click)="callModalAction.emit(item)"
+                                        class="btn border-0 me-2 icon-gray-color"
+                                        type="button"
+                                >
+                                    <i class="fas fa-pen"></i>
+                                </button>
+                                <button
+                                        [disabled]="item.code === 'DEFAULT'"
+                                        [attr.title]="
                   item.code === 'DEFAULT'
                     ? 'Este curso no se puede eliminar'
                     : null
                 "
-                (click)="openConfirmationModal(item)"
-                class="btn border-0 icon-gray-color"
-                type="button"
-              >
-                <i class="fas fa-trash"></i>
-              </button>
-            </td>
-          </tr>
-          } @empty {
-          <tr>
-            <td colspan="4">
-              <div
-                class="d-flex justify-content-center align-items-center w-100"
-              >
-                <p class="mb-0">No hay cursos registrados</p>
-              </div>
-            </td>
-          </tr>
-          }
-        </tbody>
-      </table>
+                                        (click)="openConfirmationModal(item)"
+                                        class="btn border-0 icon-gray-color"
+                                        type="button"
+                                >
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </td>
+                        </tr>
+                    } @empty {
+                        <tr>
+                            <td colspan="5">
+                                <div
+                                        class="d-flex justify-content-center align-items-center w-100"
+                                >
+                                    <p class="mb-0">No hay cursos registrados</p>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
     </div>
-  </div>
 </div>
 
 <app-confirm-modal
-  #confirmDeleteModal
-  [message]="
+    #confirmDeleteModal
+    [message]="
     '¿Estás seguro de que deseas eliminar el curso ' + deleteCourse?.title + '?'
   "
-  [confirmText]="'Eliminar'"
-  [cancelText]="'Cancelar'"
-  (confirmed)="deleteConfirmation()"
+    [confirmText]="'Eliminar'"
+    [cancelText]="'Cancelar'"
+    (confirmed)="deleteConfirmation()"
 >
 </app-confirm-modal>
+

--- a/src/app/components/courses/course-list/courses-list.component.scss
+++ b/src/app/components/courses/course-list/courses-list.component.scss
@@ -1,10 +1,19 @@
 .no-link-style {
   text-decoration: none;
-  color: inherit;
-  cursor: pointer;
+  color: var(--color-indigo-dye);
+  transition: color 0.2s ease-in-out;
 }
 
-
 .no-link-style:hover {
-  color: #007bff;
+  color: var(--color-blue-munsell);
+}
+
+.text-link-special {
+  color: var(--color-blue-munsell) !important;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.text-link-special:hover {
+  color: var(--color-indigo-dye) !important;
 }

--- a/src/app/components/material/materials-form/materials-form.component.html
+++ b/src/app/components/material/materials-form/materials-form.component.html
@@ -1,0 +1,68 @@
+<form [formGroup]="form" class="mb-4" style="max-width: 400px; margin: 0 auto">
+    <div class="mb-3 text-center">
+        <h2
+                style="
+        font-size: var(--font-h2-size);
+        font-weight: var(--font-h2-weight);
+        color: var(--color-indigo-dye);
+      "
+        >
+            {{ form.get('id')?.value ? 'Editar Material' : 'Registrar Material' }}
+        </h2>
+    </div>
+
+    <div class="mb-3">
+        <label class="mb-1" for="name">
+            Nombre del material<span class="required-asterisk">*</span>
+        </label>
+        <input
+                id="name"
+                formControlName="name"
+                type="text"
+                class="form-control normal"
+                placeholder="Nombre del material"
+        />
+        <div
+                class="form-error-message"
+                *ngIf="
+        form.controls['name'].invalid &&
+        (form.controls['name'].dirty || form.controls['name'].touched)
+      "
+        >
+            El nombre es obligatorio.
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label class="mb-1" for="fileUrl">
+            Enlace del archivo<span class="required-asterisk">*</span>
+        </label>
+        <div class="d-flex gap-2 align-items-center">
+            <input
+                    id="fileUrl"
+                    type="text"
+                    class="form-control disabled-field"
+                    formControlName="fileUrl"
+                    [readonly]="true"
+                    [disabled]="true"
+                    placeholder="Se llenará automáticamente al subir un archivo"
+            />
+            <button type="button" class="btn btn-secondary" (click)="openUploadWidget()">Subir Archivo</button>
+        </div>
+
+        @if (form.get('fileUrl')?.invalid && (form.get('fileUrl')?.dirty || form.get('fileUrl')?.touched)) {
+            <div class="form-error-message">El enlace del archivo es obligatorio.</div>
+        }
+    </div>
+
+    <div class="text-center mt-4">
+        <button
+                (click)="callSave()"
+                [disabled]="form.invalid"
+                class="btn btn-primary"
+                type="button"
+        >
+            Guardar
+        </button>
+    </div>
+</form>

--- a/src/app/components/material/materials-form/materials-form.component.html
+++ b/src/app/components/material/materials-form/materials-form.component.html
@@ -16,18 +16,18 @@
             Nombre del material<span class="required-asterisk">*</span>
         </label>
         <input
-                id="name"
-                formControlName="name"
-                type="text"
                 class="form-control normal"
+                formControlName="name"
+                id="name"
                 placeholder="Nombre del material"
+                type="text"
         />
         <div
-                class="form-error-message"
                 *ngIf="
         form.controls['name'].invalid &&
         (form.controls['name'].dirty || form.controls['name'].touched)
       "
+                class="form-error-message"
         >
             El nombre es obligatorio.
         </div>
@@ -39,15 +39,15 @@
         </label>
         <div class="d-flex gap-2 align-items-center">
             <input
-                    id="fileUrl"
-                    type="text"
+                    [disabled]="true"
+                    [readonly]="true"
                     class="form-control disabled-field"
                     formControlName="fileUrl"
-                    [readonly]="true"
-                    [disabled]="true"
+                    id="fileUrl"
                     placeholder="Se llenará automáticamente al subir un archivo"
+                    type="text"
             />
-            <button type="button" class="btn btn-secondary" (click)="openUploadWidget()">Subir Archivo</button>
+            <button (click)="openUploadWidget()" class="btn btn-secondary" type="button">Subir Archivo</button>
         </div>
 
         @if (form.get('fileUrl')?.invalid && (form.get('fileUrl')?.dirty || form.get('fileUrl')?.touched)) {

--- a/src/app/components/material/materials-form/materials-form.component.scss
+++ b/src/app/components/material/materials-form/materials-form.component.scss
@@ -1,0 +1,6 @@
+.disabled-field {
+  background-color: #e9ecef;
+  cursor: not-allowed;
+  color: #6c757d;
+  border-color: #ced4da;
+}

--- a/src/app/components/material/materials-form/materials-form.component.ts
+++ b/src/app/components/material/materials-form/materials-form.component.ts
@@ -1,0 +1,97 @@
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule, NgIf } from '@angular/common'; // NgIf is needed for the @if syntax
+import { IMaterial } from '../../../interfaces';
+import { AuthService } from '../../../services/auth.service';
+import { ActivatedRoute } from '@angular/router';
+
+// Set a reasonable max file size for documents, e.g., 20MB
+const MAX_MATERIAL_FILE_SIZE = 20 * 1024 * 1024;
+
+@Component({
+  selector: 'app-materials-form',
+  standalone: true,
+  imports: [ReactiveFormsModule, CommonModule, NgIf],
+  templateUrl: './materials-form.component.html',
+  styleUrls: ['./materials-form.component.scss']
+})
+export class MaterialsFormComponent {
+  public fb: FormBuilder = inject(FormBuilder);
+  @Input() form!: FormGroup;
+  @Output() callSaveMethod: EventEmitter<IMaterial> = new EventEmitter<IMaterial>();
+  @Output() callUpdateMethod: EventEmitter<IMaterial> = new EventEmitter<IMaterial>();
+
+  public authService: AuthService = inject(AuthService);
+  public areActionsAvailable: boolean = false;
+  public route: ActivatedRoute = inject(ActivatedRoute);
+
+  ngOnInit(): void {
+    this.authService.getUserAuthorities();
+    this.route.data.subscribe(data => {
+      this.areActionsAvailable = this.authService.areActionsAvailable(data['authorities'] ?? []);
+    });
+  }
+
+  callSave() {
+    if (this.form.invalid) return;
+
+    const item: IMaterial = {
+      id: this.form.controls['id'].value,
+      name: this.form.controls['name'].value,
+      fileUrl: this.form.controls['fileUrl'].value
+    };
+
+    if (item.id) {
+      this.callUpdateMethod.emit({ ...item, id: Number(item.id) });
+    } else {
+      this.callSaveMethod.emit(item);
+    }
+  }
+
+  openUploadWidget(): void {
+    const widget = (window as any).cloudinary.createUploadWidget(
+        {
+          cloudName: 'dghnoosr7',
+          uploadPreset: 'EduSmart',
+          sources: ['local', 'url'],
+          multiple: false,
+          resourceType: 'raw',
+          clientAllowedFormats: ['pdf', 'doc', 'docx', 'xlsx', 'pptx', 'txt'],
+          maxFileSize: MAX_MATERIAL_FILE_SIZE,
+          styles: {
+            palette: {
+              window: '#ffffff',
+              windowBorder: '#90A0B3',
+              tabIcon: '#003E6B',
+              menuIcons: '#5A616A',
+              textDark: '#000000',
+              textLight: '#FFFFFF',
+              link: '#1E8B9B',
+              action: '#003E6B',
+              inactiveTabIcon: '#69778A',
+              error: '#A83A15',
+              inProgress: '#003E6B',
+              complete: '#20B832',
+              progressBar: '#1E8B9B'
+            },
+            fonts: {
+              default: null,
+              "'Roboto', sans-serif": {
+                url: 'https://fonts.googleapis.com/css?family=Roboto',
+                active: true
+              }
+            }
+          }
+        },
+        (error: any, result: any) => {
+          if (!error && result && result.event === 'success') {
+            const url = result.info.secure_url;
+            if (url) {
+              this.form.controls['fileUrl'].setValue(url);
+            }
+          }
+        }
+    );
+    widget.open();
+  }
+}

--- a/src/app/components/material/materials-form/materials-form.component.ts
+++ b/src/app/components/material/materials-form/materials-form.component.ts
@@ -1,97 +1,97 @@
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { CommonModule, NgIf } from '@angular/common'; // NgIf is needed for the @if syntax
-import { IMaterial } from '../../../interfaces';
-import { AuthService } from '../../../services/auth.service';
-import { ActivatedRoute } from '@angular/router';
+import {Component, EventEmitter, inject, Input, Output} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule} from '@angular/forms';
+import {CommonModule, NgIf} from '@angular/common'; 
+import {IMaterial} from '../../../interfaces';
+import {AuthService} from '../../../services/auth.service';
+import {ActivatedRoute} from '@angular/router';
 
-// Set a reasonable max file size for documents, e.g., 20MB
+
 const MAX_MATERIAL_FILE_SIZE = 20 * 1024 * 1024;
 
 @Component({
-  selector: 'app-materials-form',
-  standalone: true,
-  imports: [ReactiveFormsModule, CommonModule, NgIf],
-  templateUrl: './materials-form.component.html',
-  styleUrls: ['./materials-form.component.scss']
+    selector: 'app-materials-form',
+    standalone: true,
+    imports: [ReactiveFormsModule, CommonModule, NgIf],
+    templateUrl: './materials-form.component.html',
+    styleUrls: ['./materials-form.component.scss']
 })
 export class MaterialsFormComponent {
-  public fb: FormBuilder = inject(FormBuilder);
-  @Input() form!: FormGroup;
-  @Output() callSaveMethod: EventEmitter<IMaterial> = new EventEmitter<IMaterial>();
-  @Output() callUpdateMethod: EventEmitter<IMaterial> = new EventEmitter<IMaterial>();
+    public fb: FormBuilder = inject(FormBuilder);
+    @Input() form!: FormGroup;
+    @Output() callSaveMethod: EventEmitter<IMaterial> = new EventEmitter<IMaterial>();
+    @Output() callUpdateMethod: EventEmitter<IMaterial> = new EventEmitter<IMaterial>();
 
-  public authService: AuthService = inject(AuthService);
-  public areActionsAvailable: boolean = false;
-  public route: ActivatedRoute = inject(ActivatedRoute);
+    public authService: AuthService = inject(AuthService);
+    public areActionsAvailable: boolean = false;
+    public route: ActivatedRoute = inject(ActivatedRoute);
 
-  ngOnInit(): void {
-    this.authService.getUserAuthorities();
-    this.route.data.subscribe(data => {
-      this.areActionsAvailable = this.authService.areActionsAvailable(data['authorities'] ?? []);
-    });
-  }
-
-  callSave() {
-    if (this.form.invalid) return;
-
-    const item: IMaterial = {
-      id: this.form.controls['id'].value,
-      name: this.form.controls['name'].value,
-      fileUrl: this.form.controls['fileUrl'].value
-    };
-
-    if (item.id) {
-      this.callUpdateMethod.emit({ ...item, id: Number(item.id) });
-    } else {
-      this.callSaveMethod.emit(item);
+    ngOnInit(): void {
+        this.authService.getUserAuthorities();
+        this.route.data.subscribe(data => {
+            this.areActionsAvailable = this.authService.areActionsAvailable(data['authorities'] ?? []);
+        });
     }
-  }
 
-  openUploadWidget(): void {
-    const widget = (window as any).cloudinary.createUploadWidget(
-        {
-          cloudName: 'dghnoosr7',
-          uploadPreset: 'EduSmart',
-          sources: ['local', 'url'],
-          multiple: false,
-          resourceType: 'raw',
-          clientAllowedFormats: ['pdf', 'doc', 'docx', 'xlsx', 'pptx', 'txt'],
-          maxFileSize: MAX_MATERIAL_FILE_SIZE,
-          styles: {
-            palette: {
-              window: '#ffffff',
-              windowBorder: '#90A0B3',
-              tabIcon: '#003E6B',
-              menuIcons: '#5A616A',
-              textDark: '#000000',
-              textLight: '#FFFFFF',
-              link: '#1E8B9B',
-              action: '#003E6B',
-              inactiveTabIcon: '#69778A',
-              error: '#A83A15',
-              inProgress: '#003E6B',
-              complete: '#20B832',
-              progressBar: '#1E8B9B'
-            },
-            fonts: {
-              default: null,
-              "'Roboto', sans-serif": {
-                url: 'https://fonts.googleapis.com/css?family=Roboto',
-                active: true
-              }
-            }
-          }
-        },
-        (error: any, result: any) => {
-          if (!error && result && result.event === 'success') {
-            const url = result.info.secure_url;
-            if (url) {
-              this.form.controls['fileUrl'].setValue(url);
-            }
-          }
+    callSave() {
+        if (this.form.invalid) return;
+
+        const item: IMaterial = {
+            id: this.form.controls['id'].value,
+            name: this.form.controls['name'].value,
+            fileUrl: this.form.controls['fileUrl'].value
+        };
+
+        if (item.id) {
+            this.callUpdateMethod.emit({...item, id: Number(item.id)});
+        } else {
+            this.callSaveMethod.emit(item);
         }
-    );
-    widget.open();
-  }
+    }
+
+    openUploadWidget(): void {
+        const widget = (window as any).cloudinary.createUploadWidget(
+            {
+                cloudName: 'dghnoosr7',
+                uploadPreset: 'EduSmart',
+                sources: ['local', 'url'],
+                multiple: false,
+                resourceType: 'raw',
+                clientAllowedFormats: ['pdf', 'doc', 'docx', 'xlsx', 'pptx', 'txt'],
+                maxFileSize: MAX_MATERIAL_FILE_SIZE,
+                styles: {
+                    palette: {
+                        window: '#ffffff',
+                        windowBorder: '#90A0B3',
+                        tabIcon: '#003E6B',
+                        menuIcons: '#5A616A',
+                        textDark: '#000000',
+                        textLight: '#FFFFFF',
+                        link: '#1E8B9B',
+                        action: '#003E6B',
+                        inactiveTabIcon: '#69778A',
+                        error: '#A83A15',
+                        inProgress: '#003E6B',
+                        complete: '#20B832',
+                        progressBar: '#1E8B9B'
+                    },
+                    fonts: {
+                        default: null,
+                        "'Roboto', sans-serif": {
+                            url: 'https://fonts.googleapis.com/css?family=Roboto',
+                            active: true
+                        }
+                    }
+                }
+            },
+            (error: any, result: any) => {
+                if (!error && result && result.event === 'success') {
+                    const url = result.info.secure_url;
+                    if (url) {
+                        this.form.controls['fileUrl'].setValue(url);
+                    }
+                }
+            }
+        );
+        widget.open();
+    }
 }

--- a/src/app/components/material/materials-list/materials-list.component.html
+++ b/src/app/components/material/materials-list/materials-list.component.html
@@ -9,10 +9,10 @@
 
         <div class="mb-4 mt-2">
             <input
-                    type="text"
+                    [(ngModel)]="searchText"
                     class="input-txt input-filter"
                     placeholder="Filtrar por nombre..."
-                    [(ngModel)]="searchText"
+                    type="text"
             />
         </div>
 
@@ -31,8 +31,8 @@
                 <tr *ngFor="let item of filteredMaterials; trackBy: trackById">
                     <td>{{ item.name }}</td>
                     <td>
-                        <a [href]="item.fileUrl" target="_blank" rel="noopener noreferrer"
-                           class="d-flex align-items-center link-material">
+                        <a [href]="item.fileUrl" class="d-flex align-items-center link-material" rel="noopener noreferrer"
+                           target="_blank">
                             <i [class]="getFileIcon(item.fileUrl)" class="me-2"
                                style="font-size: 1.5em;"></i>
                             <span>Abrir</span>
@@ -44,16 +44,16 @@
                         <button
                                 (click)="callModalAction.emit(item)"
                                 class="btn border-0 me-2 icon-gray-color"
-                                type="button"
                                 title="Editar material"
+                                type="button"
                         >
                             <i class="fas fa-pen"></i>
                         </button>
                         <button
                                 (click)="openConfirmationModal(item)"
                                 class="btn border-0 icon-gray-color"
-                                type="button"
                                 title="Eliminar material"
+                                type="button"
                         >
                             <i class="fas fa-trash"></i>
                         </button>
@@ -73,9 +73,9 @@
 
     <app-confirm-modal
         #confirmDeleteModal
-        [message]="'¿Estás seguro de que deseas eliminar el material ' + deleteMaterial?.name + '?'"
-        [confirmText]="'Eliminar'"
-        [cancelText]="'Cancelar'"
         (confirmed)="deleteConfirmation()"
+        [cancelText]="'Cancelar'"
+        [confirmText]="'Eliminar'"
+        [message]="'¿Estás seguro de que deseas eliminar el material ' + deleteMaterial?.name + '?'"
     ></app-confirm-modal>
 </div>

--- a/src/app/components/material/materials-list/materials-list.component.html
+++ b/src/app/components/material/materials-list/materials-list.component.html
@@ -1,0 +1,81 @@
+<div class="card">
+    <div class="card-header card-header-indigo">
+        <h2 class="mb-0">Lista de Materiales</h2>
+    </div>
+    <div class="card-body">
+        <p class="text-muted mb-3">
+            Materiales registrados para el curso seleccionado.
+        </p>
+
+        <div class="mb-4 mt-2">
+            <input
+                    type="text"
+                    class="input-txt input-filter"
+                    placeholder="Filtrar por nombre..."
+                    [(ngModel)]="searchText"
+            />
+        </div>
+
+        <div class="table-container table-responsive">
+            <table class="table custom-full-bordered-table">
+                <thead class="table-header-gray">
+                <tr>
+                    <th scope="col">Nombre</th>
+                    <th scope="col">Archivo</th>
+                    <th scope="col">Fecha de subida</th>
+                    <th scope="col">Profesor</th>
+                    <th class="text-center" scope="col">Acciones</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr *ngFor="let item of filteredMaterials; trackBy: trackById">
+                    <td>{{ item.name }}</td>
+                    <td>
+                        <a [href]="item.fileUrl" target="_blank" rel="noopener noreferrer"
+                           class="d-flex align-items-center link-material">
+                            <i [class]="getFileIcon(item.fileUrl)" class="me-2"
+                               style="font-size: 1.5em;"></i>
+                            <span>Abrir</span>
+                        </a>
+                    </td>
+                    <td>{{ item.uploadedAt | date: 'mediumDate' }}</td>
+                    <td>{{ item.teacher?.name || 'Sin asignar' }}</td>
+                    <td class="text-center">
+                        <button
+                                (click)="callModalAction.emit(item)"
+                                class="btn border-0 me-2 icon-gray-color"
+                                type="button"
+                                title="Editar material"
+                        >
+                            <i class="fas fa-pen"></i>
+                        </button>
+                        <button
+                                (click)="openConfirmationModal(item)"
+                                class="btn border-0 icon-gray-color"
+                                type="button"
+                                title="Eliminar material"
+                        >
+                            <i class="fas fa-trash"></i>
+                        </button>
+                    </td>
+                </tr>
+                <tr *ngIf="filteredMaterials.length === 0">
+                    <td colspan="5">
+                        <div class="d-flex justify-content-center align-items-center w-100">
+                            <p class="mb-0" style="color: var(--color-indigo-dye);">No hay materiales registrados</p>
+                        </div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <app-confirm-modal
+        #confirmDeleteModal
+        [message]="'¿Estás seguro de que deseas eliminar el material ' + deleteMaterial?.name + '?'"
+        [confirmText]="'Eliminar'"
+        [cancelText]="'Cancelar'"
+        (confirmed)="deleteConfirmation()"
+    ></app-confirm-modal>
+</div>

--- a/src/app/components/material/materials-list/materials-list.component.scss
+++ b/src/app/components/material/materials-list/materials-list.component.scss
@@ -7,18 +7,22 @@
 .no-link-style:hover {
   color: #007bff;
 }
+
 .link-material {
   color: var(--color-indigo-dye);
   text-decoration: none;
   transition: color 0.2s ease-in-out;
 }
+
 .link-material:hover {
   color: var(--color-blue-munsell);
 }
+
 .link-material i {
   color: var(--color-blue-munsell);
   transition: color 0.2s ease-in-out;
 }
+
 .link-material:hover i {
   color: var(--color-indigo-dye);
 }

--- a/src/app/components/material/materials-list/materials-list.component.scss
+++ b/src/app/components/material/materials-list/materials-list.component.scss
@@ -1,0 +1,24 @@
+.no-link-style {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.no-link-style:hover {
+  color: #007bff;
+}
+.link-material {
+  color: var(--color-indigo-dye);
+  text-decoration: none;
+  transition: color 0.2s ease-in-out;
+}
+.link-material:hover {
+  color: var(--color-blue-munsell);
+}
+.link-material i {
+  color: var(--color-blue-munsell);
+  transition: color 0.2s ease-in-out;
+}
+.link-material:hover i {
+  color: var(--color-indigo-dye);
+}

--- a/src/app/components/material/materials-list/materials-list.component.ts
+++ b/src/app/components/material/materials-list/materials-list.component.ts
@@ -1,11 +1,4 @@
-import {
-    Component,
-    EventEmitter,
-    Input,
-    Output,
-    ViewChild,
-    inject,
-} from "@angular/core";
+import {Component, EventEmitter, Input, Output, ViewChild,} from "@angular/core";
 import {IMaterial} from "../../../interfaces";
 import {ConfirmModalComponent} from "../../confirm-modal/confirm-modal.component";
 import {DatePipe, NgForOf, NgIf} from "@angular/common";

--- a/src/app/components/material/materials-list/materials-list.component.ts
+++ b/src/app/components/material/materials-list/materials-list.component.ts
@@ -1,0 +1,78 @@
+import {
+    Component,
+    EventEmitter,
+    Input,
+    Output,
+    ViewChild,
+    inject,
+} from "@angular/core";
+import {IMaterial} from "../../../interfaces";
+import {ConfirmModalComponent} from "../../confirm-modal/confirm-modal.component";
+import {DatePipe, NgForOf, NgIf} from "@angular/common";
+import {FormsModule} from "@angular/forms";
+
+@Component({
+    selector: "app-materials-list",
+    standalone: true,
+    imports: [ConfirmModalComponent, NgForOf, NgIf, FormsModule, DatePipe],
+    templateUrl: "./materials-list.component.html",
+    styleUrls: ["./materials-list.component.scss"],
+})
+export class MaterialListComponent {
+    @Input() materials: IMaterial[] = [];
+    @Output() callModalAction = new EventEmitter<IMaterial>();
+    @Output() callDeleteAction = new EventEmitter<IMaterial>();
+
+    deleteMaterial: IMaterial | null = null;
+    searchText: string = "";
+
+    @ViewChild("confirmDeleteModal") confirmDeleteModal!: ConfirmModalComponent;
+
+    get filteredMaterials(): IMaterial[] {
+        if (!this.searchText) return this.materials;
+        const lower = this.searchText.toLowerCase();
+        return this.materials.filter((m) =>
+            m.name?.toLowerCase().includes(lower)
+        );
+    }
+
+    openConfirmationModal(material: IMaterial): void {
+        this.deleteMaterial = material;
+        this.confirmDeleteModal.show();
+    }
+
+    deleteConfirmation(): void {
+        if (this.deleteMaterial) {
+            this.callDeleteAction.emit(this.deleteMaterial);
+            this.deleteMaterial = null;
+        }
+    }
+
+    trackById(index: number, item: IMaterial) {
+        return item.id;
+    }
+
+    getFileIcon(fileUrl: string): string {
+        const fileExtension = fileUrl.split('.').pop()?.toLowerCase();
+        switch (fileExtension) {
+            case 'pdf':
+                return 'fas fa-file-pdf';
+            case 'doc':
+            case 'docx':
+                return 'fas fa-file-word';
+            case 'xls':
+            case 'xlsx':
+                return 'fas fa-file-excel';
+            case 'ppt':
+            case 'pptx':
+                return 'fas fa-file-powerpoint';
+            case 'txt':
+                return 'fas fa-file-alt';
+            case 'zip':
+            case 'rar':
+                return 'fas fa-file-archive';
+            default:
+                return 'fas fa-file';
+        }
+    }
+}

--- a/src/app/components/stories/story-form/stories-form.component.html
+++ b/src/app/components/stories/story-form/stories-form.component.html
@@ -1,68 +1,68 @@
 <form [formGroup]="form" class="mb-4" style="max-width: 400px; margin: 0 auto">
-  <div class="mb-3 text-center">
-    <h2
-      style="
+    <div class="mb-3 text-center">
+        <h2
+                style="
         font-size: var(--font-h2-size);
         font-weight: var(--font-h2-weight);
         color: var(--color-indigo-dye);
       "
-    >
-      Registrar Historia
-    </h2>
-  </div>
+        >
+            Registrar Historia
+        </h2>
+    </div>
 
-  <div class="mb-3">
-    <label class="mb-1" for="title">
-      Título<span class="required-asterisk">*</span>
-    </label>
-    <input
-      id="title"
-      formControlName="title"
-      type="text"
-      class="form-control normal"
-      placeholder="Ej: La llegada de los españoles al Nuevo Mundo"
-    />
-    <div
-      class="form-error-message"
-      *ngIf="
+    <div class="mb-3">
+        <label class="mb-1" for="title">
+            Título<span class="required-asterisk">*</span>
+        </label>
+        <input
+                id="title"
+                formControlName="title"
+                type="text"
+                class="form-control normal"
+                placeholder="Ej: La llegada de los españoles al Nuevo Mundo"
+        />
+        <div
+                class="form-error-message"
+                *ngIf="
         form.controls['title'].invalid &&
         (form.controls['title'].dirty || form.controls['title'].touched)
       "
-    >
-      El título es obligatorio.
+        >
+            El título es obligatorio.
+        </div>
     </div>
-  </div>
 
-  <div class="mb-3">
-    <label class="mb-1" for="content">
-      Contenido<span class="required-asterisk">*</span>
-    </label>
-    <textarea
-      id="content"
-      formControlName="content"
-      class="form-control normal"
-      rows="10"
-      placeholder="Escribe aquí el contenido de la historia"
-    ></textarea>
-    <div
-      class="form-error-message"
-      *ngIf="
+    <div class="mb-3">
+        <label class="mb-1" for="content">
+            Contenido<span class="required-asterisk">*</span>
+        </label>
+        <textarea
+                id="content"
+                formControlName="content"
+                class="form-control normal"
+                rows="10"
+                placeholder="Escribe aquí el contenido de la historia"
+        ></textarea>
+        <div
+                class="form-error-message"
+                *ngIf="
         form.controls['content'].invalid &&
         (form.controls['content'].dirty || form.controls['content'].touched)
       "
-    >
-      El contenido es obligatorio.
+        >
+            El contenido es obligatorio.
+        </div>
     </div>
-  </div>
 
-  <div class="text-center mt-4">
-    <button
-      (click)="callSave()"
-      [disabled]="form.invalid"
-      class="btn btn-primary"
-      type="button"
-    >
-      Guardar
-    </button>
-  </div>
+    <div class="text-center mt-4">
+        <button
+                (click)="callSave()"
+                [disabled]="form.invalid"
+                class="btn btn-primary"
+                type="button"
+        >
+            Guardar
+        </button>
+    </div>
 </form>

--- a/src/app/interfaces/index.ts
+++ b/src/app/interfaces/index.ts
@@ -154,3 +154,13 @@ export interface IOption {
   correct: boolean;
   question?: IQuestion;
 }
+
+export interface IMaterial {
+  id?: number;
+  name: string;
+  fileUrl: string;
+  uploadedAt?: string;
+  course?: Partial<ICourse> | null;
+  teacher?: Partial<IUser> | null;
+}
+

--- a/src/app/pages/materials/materials.component.html
+++ b/src/app/pages/materials/materials.component.html
@@ -1,6 +1,6 @@
 <div class="row p-4">
     <div class="col-12 mb-3">
-        <h2 class="title-highlight">Historia</h2>
+        <h2 class="title-highlight">Materiales</h2>
     </div>
 
     <div class="col-12">
@@ -8,7 +8,7 @@
             <button (click)="goBack()" class="btn custom-add-full-btn">
                 <i class="fas fa-arrow-left me-2"></i> Volver
             </button>
-            <button (click)="openAddStoryModal()" class="btn custom-add-full-btn">
+            <button (click)="openAddMaterialModal()" class="btn custom-add-full-btn">
                 <i class="fas fa-plus me-2"></i> Agregar
             </button>
         </div>
@@ -17,16 +17,16 @@
     <div class="col-12 mt-3">
         <div class="card">
             <div class="card-body">
-                <app-story-list
-                        [stories]="storyList()"
-                        (callModalAction)="openEditStoryModal($event)"
-                        (callDeleteAction)="deleteStory($event)">
-                </app-story-list>
+                <app-materials-list
+                        [materials]="materials()"
+                        (callModalAction)="openEditMaterialModal($event)"
+                        (callDeleteAction)="deleteMaterial($event)">
+                </app-materials-list>
 
-                @if (storyList().length) {
+                @if (materials().length) {
                     <app-pagination
-                            [service]="storyService.search"
-                            [loadFunction]="loadStories.bind(this)">
+                            [service]="materialService.search"
+                            [loadFunction]="loadMaterials.bind(this)">
                     </app-pagination>
                 }
             </div>
@@ -34,21 +34,21 @@
     </div>
 </div>
 
-<ng-template #addStoryModal>
+<ng-template #addMaterialModal>
     <app-modal [hideFooter]="true">
-        <app-stories-form
-                [form]="storyForm"
-                (callSaveMethod)="handleAddStory($event)">
-        </app-stories-form>
+        <app-materials-form
+                [form]="materialForm"
+                (callSaveMethod)="handleAddMaterial($event)">
+        </app-materials-form>
     </app-modal>
 </ng-template>
 
-<ng-template #editStoryModal>
+<ng-template #editMaterialModal>
     <app-modal [hideFooter]="true">
-        <app-stories-form
-                [form]="storyForm"
+        <app-materials-form
+                [form]="materialForm"
                 (callUpdateMethod)="confirmEdit($event)">
-        </app-stories-form>
+        </app-materials-form>
     </app-modal>
 </ng-template>
 
@@ -56,7 +56,7 @@
     <app-modal [hideFooter]="true">
         <div class="text-center p-4">
             <h2>Confirmación</h2>
-            <p>¿Está seguro que desea modificar la historia?</p>
+            <p>¿Está seguro que desea modificar el material?</p>
             <div class="d-flex justify-content-center mt-4">
                 <button class="btn btn-secondary me-2" (click)="cancelEdit()">Cancelar</button>
                 <button class="btn btn-primary" (click)="confirmEditFinal()">Sí, modificar</button>

--- a/src/app/pages/materials/materials.component.html
+++ b/src/app/pages/materials/materials.component.html
@@ -18,9 +18,9 @@
         <div class="card">
             <div class="card-body">
                 <app-materials-list
-                        [materials]="materials()"
+                        (callDeleteAction)="deleteMaterial($event)"
                         (callModalAction)="openEditMaterialModal($event)"
-                        (callDeleteAction)="deleteMaterial($event)">
+                        [materials]="materials()">
                 </app-materials-list>
 
                 @if (materials().length) {
@@ -37,8 +37,8 @@
 <ng-template #addMaterialModal>
     <app-modal [hideFooter]="true">
         <app-materials-form
-                [form]="materialForm"
-                (callSaveMethod)="handleAddMaterial($event)">
+                (callSaveMethod)="handleAddMaterial($event)"
+                [form]="materialForm">
         </app-materials-form>
     </app-modal>
 </ng-template>
@@ -46,8 +46,8 @@
 <ng-template #editMaterialModal>
     <app-modal [hideFooter]="true">
         <app-materials-form
-                [form]="materialForm"
-                (callUpdateMethod)="confirmEdit($event)">
+                (callUpdateMethod)="confirmEdit($event)"
+                [form]="materialForm">
         </app-materials-form>
     </app-modal>
 </ng-template>
@@ -58,8 +58,8 @@
             <h2>Confirmación</h2>
             <p>¿Está seguro que desea modificar el material?</p>
             <div class="d-flex justify-content-center mt-4">
-                <button class="btn btn-secondary me-2" (click)="cancelEdit()">Cancelar</button>
-                <button class="btn btn-primary" (click)="confirmEditFinal()">Sí, modificar</button>
+                <button (click)="cancelEdit()" class="btn btn-secondary me-2">Cancelar</button>
+                <button (click)="confirmEditFinal()" class="btn btn-primary">Sí, modificar</button>
             </div>
         </div>
     </app-modal>

--- a/src/app/pages/materials/materials.component.scss
+++ b/src/app/pages/materials/materials.component.scss
@@ -1,0 +1,78 @@
+.custom-add-full-btn {
+  background-color: #003E6B;
+  color: #fff;
+  border: 1px solid #003E6B;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+  font-weight: bold;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.custom-add-full-btn:hover {
+  background-color: #002e50;
+  border-color: #002e50;
+}
+
+.custom-add-full-btn:focus {
+  box-shadow: 0 0 0 0.25rem rgba(0, 62, 107, 0.5);
+}
+
+
+.custom-full-bordered-table {
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid #e9ecef;
+}
+
+
+.custom-full-bordered-table thead th {
+  border-bottom: 1px solid #e9ecef;
+  border-right: 1px solid #e9ecef;
+  color: #495057;
+}
+
+.custom-full-bordered-table thead th:last-child {
+  border-right: none;
+}
+
+.table-header-gray {
+  background-color: #f8f9fa;
+}
+
+
+.custom-full-bordered-table tbody tr td,
+.custom-full-bordered-table tbody tr th {
+  color: #212529;
+  border-bottom: 1px solid #e9ecef;
+  border-right: 1px solid #e9ecef;
+}
+
+
+.custom-full-bordered-table tbody tr:last-child td,
+.custom-full-bordered-table tbody tr:last-child th {
+  border-bottom: none;
+}
+
+
+.custom-full-bordered-table tbody tr td:last-child,
+.custom-full-bordered-table tbody tr th:last-child {
+  border-right: none;
+}
+
+
+.btn.border-0 {
+  border: 0 !important;
+}
+
+
+.icon-gray-color {
+  color: #6c757d;
+}
+
+.icon-gray-color:hover {
+  color: #495057;
+}

--- a/src/app/pages/materials/materials.component.ts
+++ b/src/app/pages/materials/materials.component.ts
@@ -1,157 +1,154 @@
-import { Component, OnInit, ViewChild, WritableSignal, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { PaginationComponent } from '../../components/pagination/pagination.component';
-import { ModalComponent } from '../../components/modal/modal.component';
-import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
-import { ModalService } from '../../services/modal.service';
-import { AuthService } from '../../services/auth.service';
-import { MaterialService } from '../../services/material.service';
-import { IMaterial } from '../../interfaces';
-import { MaterialsFormComponent } from "../../components/material/materials-form/materials-form.component";
-import { MaterialListComponent } from "../../components/material/materials-list/materials-list.component";
+import {Component, inject, OnInit, ViewChild, WritableSignal} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {PaginationComponent} from '../../components/pagination/pagination.component';
+import {ModalComponent} from '../../components/modal/modal.component';
+import {FormBuilder, ReactiveFormsModule, Validators} from '@angular/forms';
+import {ActivatedRoute} from '@angular/router';
+import {ModalService} from '../../services/modal.service';
+import {AuthService} from '../../services/auth.service';
+import {MaterialService} from '../../services/material.service';
+import {IMaterial} from '../../interfaces';
+import {MaterialsFormComponent} from "../../components/material/materials-form/materials-form.component";
+import {MaterialListComponent} from "../../components/material/materials-list/materials-list.component";
 
 @Component({
-  selector: 'app-materials',
-  standalone: true,
-  imports: [
-    CommonModule,
-    PaginationComponent,
-    ModalComponent,
-    MaterialsFormComponent,
-    MaterialListComponent,
-    ReactiveFormsModule,
-  ],
-  templateUrl: './materials.component.html',
-  styleUrls: ['./materials.component.scss']
+    selector: 'app-materials',
+    standalone: true,
+    imports: [
+        CommonModule,
+        PaginationComponent,
+        ModalComponent,
+        MaterialsFormComponent,
+        MaterialListComponent,
+        ReactiveFormsModule,
+    ],
+    templateUrl: './materials.component.html',
+    styleUrls: ['./materials.component.scss']
 })
 export class MaterialsComponent implements OnInit {
-  public materials!: WritableSignal<IMaterial[]>;
-  public materialService = inject(MaterialService);
-  public modalService = inject(ModalService);
-  public authService = inject(AuthService);
-  public fb = inject(FormBuilder);
-  public route = inject(ActivatedRoute);
-
-  private courseId: number | null = null;
-  private originalMaterial: IMaterial | null = null;
-  private pendingEditItem: IMaterial | null = null;
-
-  @ViewChild('editMaterialModal') public editMaterialModal: any;
-  @ViewChild('addMaterialModal') public addMaterialModal: any;
-  @ViewChild('editConfirmationModal') public editConfirmationModal: any;
-
-  materialForm = this.fb.group({
-    id: [''],
-    name: ['', Validators.required],
-    fileUrl: ['', Validators.required],
-    course: [null],
-    teacher: [null]
-  });
-
-  constructor() {
-    this.materials = this.materialService.materials$;
-  }
-
-  ngOnInit(): void {
-    this.route.queryParams.subscribe(params => {
-      const id = Number(params['courseId']);
-      if (id) {
-        this.courseId = id;
-        sessionStorage.setItem('courseId', id.toString());
-        this.materialService.setCurrentCourseId(id);
-      } else {
-        const storedId = sessionStorage.getItem('courseId');
-        this.courseId = storedId ? Number(storedId) : null;
-        this.materialService.setCurrentCourseId(this.courseId);
-      }
-      this.loadMaterials();
+    public materials!: WritableSignal<IMaterial[]>;
+    public materialService = inject(MaterialService);
+    public modalService = inject(ModalService);
+    public authService = inject(AuthService);
+    public fb = inject(FormBuilder);
+    public route = inject(ActivatedRoute);
+    @ViewChild('editMaterialModal') public editMaterialModal: any;
+    @ViewChild('addMaterialModal') public addMaterialModal: any;
+    @ViewChild('editConfirmationModal') public editConfirmationModal: any;
+    materialForm = this.fb.group({
+        id: [''],
+        name: ['', Validators.required],
+        fileUrl: ['', Validators.required],
+        course: [null],
+        teacher: [null]
     });
-  }
+    private courseId: number | null = null;
+    private originalMaterial: IMaterial | null = null;
+    private pendingEditItem: IMaterial | null = null;
 
-  loadMaterials(): void {
-    if (this.courseId) {
-      this.materialService.getByCourse(this.courseId);
+    constructor() {
+        this.materials = this.materialService.materials$;
     }
-  }
 
-  handleAddMaterial(item: IMaterial) {
-    const teacher = this.authService.getUser();
-    const courseId = this.courseId;
-    const teacherId = teacher?.id;
-
-    if (courseId == null || teacherId == null) return;
-
-    const payload: Partial<IMaterial> = {
-      name: item.name,
-      fileUrl: item.fileUrl,
-      uploadedAt: new Date().toISOString()
-    };
-
-    this.materialService.save(payload as IMaterial, courseId, teacherId);
-    this.modalService.closeAll();
-    this.materialForm.reset();
-  }
-
-  updateMaterial() {
-    if (!this.originalMaterial) return;
-
-    const payloadToSend: IMaterial = {
-      id: this.originalMaterial.id,
-      name: this.materialForm.controls['name'].value || '',
-      fileUrl: this.materialForm.controls['fileUrl'].value || '',
-      uploadedAt: this.originalMaterial.uploadedAt,
-      course: this.originalMaterial.course ? { id: this.originalMaterial.course.id } : null,
-      teacher: this.originalMaterial.teacher ? { id: this.originalMaterial.teacher.id } : null
-    };
-
-    this.materialService.update(payloadToSend, () => {
-      this.modalService.closeAll();
-      this.materialForm.reset();
-      this.originalMaterial = null;
-    });
-  }
-
-  deleteMaterial(item: IMaterial) {
-    if (!this.courseId || !item.id) return;
-    this.materialService.delete(item);
-  }
-
-  openEditMaterialModal(material: IMaterial) {
-    this.originalMaterial = material;
-    this.materialForm.patchValue({
-      id: JSON.stringify(material.id) ,
-      name: material.name,
-      fileUrl: material.fileUrl
-    });
-    this.modalService.displayModal('lg', this.editMaterialModal);
-  }
-
-  openAddMaterialModal() {
-    this.materialForm.reset();
-    this.modalService.displayModal('md', this.addMaterialModal);
-  }
-
-  confirmEdit(item: IMaterial) {
-    this.pendingEditItem = item;
-    this.modalService.closeAll();
-    this.modalService.displayModal('sm', this.editConfirmationModal);
-  }
-
-  cancelEdit() {
-    this.pendingEditItem = null;
-    this.modalService.closeAll();
-    this.modalService.displayModal('lg', this.editMaterialModal);
-  }
-
-  confirmEditFinal() {
-    if (this.pendingEditItem) {
-      this.updateMaterial();
-      this.pendingEditItem = null;
+    ngOnInit(): void {
+        this.route.queryParams.subscribe(params => {
+            const id = Number(params['courseId']);
+            if (id) {
+                this.courseId = id;
+                sessionStorage.setItem('courseId', id.toString());
+                this.materialService.setCurrentCourseId(id);
+            } else {
+                const storedId = sessionStorage.getItem('courseId');
+                this.courseId = storedId ? Number(storedId) : null;
+                this.materialService.setCurrentCourseId(this.courseId);
+            }
+            this.loadMaterials();
+        });
     }
-  }
 
-  goBack() {
-    window.history.back();
-  }
+    loadMaterials(): void {
+        if (this.courseId) {
+            this.materialService.getByCourse(this.courseId);
+        }
+    }
+
+    handleAddMaterial(item: IMaterial) {
+        const teacher = this.authService.getUser();
+        const courseId = this.courseId;
+        const teacherId = teacher?.id;
+
+        if (courseId == null || teacherId == null) return;
+
+        const payload: Partial<IMaterial> = {
+            name: item.name,
+            fileUrl: item.fileUrl,
+            uploadedAt: new Date().toISOString()
+        };
+
+        this.materialService.save(payload as IMaterial, courseId, teacherId);
+        this.modalService.closeAll();
+        this.materialForm.reset();
+    }
+
+    updateMaterial() {
+        if (!this.originalMaterial) return;
+
+        const payloadToSend: IMaterial = {
+            id: this.originalMaterial.id,
+            name: this.materialForm.controls['name'].value || '',
+            fileUrl: this.materialForm.controls['fileUrl'].value || '',
+            uploadedAt: this.originalMaterial.uploadedAt,
+            course: this.originalMaterial.course ? {id: this.originalMaterial.course.id} : null,
+            teacher: this.originalMaterial.teacher ? {id: this.originalMaterial.teacher.id} : null
+        };
+
+        this.materialService.update(payloadToSend, () => {
+            this.modalService.closeAll();
+            this.materialForm.reset();
+            this.originalMaterial = null;
+        });
+    }
+
+    deleteMaterial(item: IMaterial) {
+        if (!this.courseId || !item.id) return;
+        this.materialService.delete(item);
+    }
+
+    openEditMaterialModal(material: IMaterial) {
+        this.originalMaterial = material;
+        this.materialForm.patchValue({
+            id: JSON.stringify(material.id),
+            name: material.name,
+            fileUrl: material.fileUrl
+        });
+        this.modalService.displayModal('lg', this.editMaterialModal);
+    }
+
+    openAddMaterialModal() {
+        this.materialForm.reset();
+        this.modalService.displayModal('md', this.addMaterialModal);
+    }
+
+    confirmEdit(item: IMaterial) {
+        this.pendingEditItem = item;
+        this.modalService.closeAll();
+        this.modalService.displayModal('sm', this.editConfirmationModal);
+    }
+
+    cancelEdit() {
+        this.pendingEditItem = null;
+        this.modalService.closeAll();
+        this.modalService.displayModal('lg', this.editMaterialModal);
+    }
+
+    confirmEditFinal() {
+        if (this.pendingEditItem) {
+            this.updateMaterial();
+            this.pendingEditItem = null;
+        }
+    }
+
+    goBack() {
+        window.history.back();
+    }
 }

--- a/src/app/pages/materials/materials.component.ts
+++ b/src/app/pages/materials/materials.component.ts
@@ -1,0 +1,157 @@
+import { Component, OnInit, ViewChild, WritableSignal, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PaginationComponent } from '../../components/pagination/pagination.component';
+import { ModalComponent } from '../../components/modal/modal.component';
+import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { ModalService } from '../../services/modal.service';
+import { AuthService } from '../../services/auth.service';
+import { MaterialService } from '../../services/material.service';
+import { IMaterial } from '../../interfaces';
+import { MaterialsFormComponent } from "../../components/material/materials-form/materials-form.component";
+import { MaterialListComponent } from "../../components/material/materials-list/materials-list.component";
+
+@Component({
+  selector: 'app-materials',
+  standalone: true,
+  imports: [
+    CommonModule,
+    PaginationComponent,
+    ModalComponent,
+    MaterialsFormComponent,
+    MaterialListComponent,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './materials.component.html',
+  styleUrls: ['./materials.component.scss']
+})
+export class MaterialsComponent implements OnInit {
+  public materials!: WritableSignal<IMaterial[]>;
+  public materialService = inject(MaterialService);
+  public modalService = inject(ModalService);
+  public authService = inject(AuthService);
+  public fb = inject(FormBuilder);
+  public route = inject(ActivatedRoute);
+
+  private courseId: number | null = null;
+  private originalMaterial: IMaterial | null = null;
+  private pendingEditItem: IMaterial | null = null;
+
+  @ViewChild('editMaterialModal') public editMaterialModal: any;
+  @ViewChild('addMaterialModal') public addMaterialModal: any;
+  @ViewChild('editConfirmationModal') public editConfirmationModal: any;
+
+  materialForm = this.fb.group({
+    id: [''],
+    name: ['', Validators.required],
+    fileUrl: ['', Validators.required],
+    course: [null],
+    teacher: [null]
+  });
+
+  constructor() {
+    this.materials = this.materialService.materials$;
+  }
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {
+      const id = Number(params['courseId']);
+      if (id) {
+        this.courseId = id;
+        sessionStorage.setItem('courseId', id.toString());
+        this.materialService.setCurrentCourseId(id);
+      } else {
+        const storedId = sessionStorage.getItem('courseId');
+        this.courseId = storedId ? Number(storedId) : null;
+        this.materialService.setCurrentCourseId(this.courseId);
+      }
+      this.loadMaterials();
+    });
+  }
+
+  loadMaterials(): void {
+    if (this.courseId) {
+      this.materialService.getByCourse(this.courseId);
+    }
+  }
+
+  handleAddMaterial(item: IMaterial) {
+    const teacher = this.authService.getUser();
+    const courseId = this.courseId;
+    const teacherId = teacher?.id;
+
+    if (courseId == null || teacherId == null) return;
+
+    const payload: Partial<IMaterial> = {
+      name: item.name,
+      fileUrl: item.fileUrl,
+      uploadedAt: new Date().toISOString()
+    };
+
+    this.materialService.save(payload as IMaterial, courseId, teacherId);
+    this.modalService.closeAll();
+    this.materialForm.reset();
+  }
+
+  updateMaterial() {
+    if (!this.originalMaterial) return;
+
+    const payloadToSend: IMaterial = {
+      id: this.originalMaterial.id,
+      name: this.materialForm.controls['name'].value || '',
+      fileUrl: this.materialForm.controls['fileUrl'].value || '',
+      uploadedAt: this.originalMaterial.uploadedAt,
+      course: this.originalMaterial.course ? { id: this.originalMaterial.course.id } : null,
+      teacher: this.originalMaterial.teacher ? { id: this.originalMaterial.teacher.id } : null
+    };
+
+    this.materialService.update(payloadToSend, () => {
+      this.modalService.closeAll();
+      this.materialForm.reset();
+      this.originalMaterial = null;
+    });
+  }
+
+  deleteMaterial(item: IMaterial) {
+    if (!this.courseId || !item.id) return;
+    this.materialService.delete(item);
+  }
+
+  openEditMaterialModal(material: IMaterial) {
+    this.originalMaterial = material;
+    this.materialForm.patchValue({
+      id: JSON.stringify(material.id) ,
+      name: material.name,
+      fileUrl: material.fileUrl
+    });
+    this.modalService.displayModal('lg', this.editMaterialModal);
+  }
+
+  openAddMaterialModal() {
+    this.materialForm.reset();
+    this.modalService.displayModal('md', this.addMaterialModal);
+  }
+
+  confirmEdit(item: IMaterial) {
+    this.pendingEditItem = item;
+    this.modalService.closeAll();
+    this.modalService.displayModal('sm', this.editConfirmationModal);
+  }
+
+  cancelEdit() {
+    this.pendingEditItem = null;
+    this.modalService.closeAll();
+    this.modalService.displayModal('lg', this.editMaterialModal);
+  }
+
+  confirmEditFinal() {
+    if (this.pendingEditItem) {
+      this.updateMaterial();
+      this.pendingEditItem = null;
+    }
+  }
+
+  goBack() {
+    window.history.back();
+  }
+}

--- a/src/app/services/material.service.ts
+++ b/src/app/services/material.service.ts
@@ -1,167 +1,167 @@
-import { inject, Injectable, signal, WritableSignal } from '@angular/core';
-import { BaseService } from './base-service';
-import { AlertService } from './alert.service';
-import { IMaterial, ISearch, IResponse } from '../interfaces';
+import {inject, Injectable, signal, WritableSignal} from '@angular/core';
+import {BaseService} from './base-service';
+import {AlertService} from './alert.service';
+import {IMaterial, ISearch, IResponse} from '../interfaces';
 
 @Injectable({
-  providedIn: 'root'
+    providedIn: 'root'
 })
 export class MaterialService extends BaseService<IMaterial> {
-  protected override source = 'materials';
+    protected override source = 'materials';
 
-  private alertService = inject(AlertService);
-  private materialListSignal = signal<IMaterial[]>([]);
+    private alertService = inject(AlertService);
+    private materialListSignal = signal<IMaterial[]>([]);
 
-  public search: ISearch = {
-    page: 1,
-    size: 5,
-    pageNumber: 1,
-    totalPages: 1,
-  };
-
-  public totalItems: number[] = [];
-
-  private currentCourseId: number | null = null;
-  private currentTeacherId: number | null = null;
-
-  get materials$() {
-    return this.materialListSignal;
-  }
-
-  setCurrentCourseId(courseId: number | null) {
-    this.currentCourseId = courseId;
-  }
-
-  setCurrentTeacherId(teacherId: number | null) {
-    this.currentTeacherId = teacherId;
-  }
-
-  getByCourse(courseId: number) {
-    this.setCurrentCourseId(courseId);
-    const params = {
-      page: this.search.page,
-      size: this.search.size,
+    public search: ISearch = {
+        page: 1,
+        size: 5,
+        pageNumber: 1,
+        totalPages: 1,
     };
 
-    this.findAllWithParamsAndCustomSource(`course/${courseId}/materials`, params).subscribe({
-      next: (response: IResponse<IMaterial[]>) => {
-        this.search = { ...this.search, ...response.meta };
-        this.totalItems = Array.from({ length: this.search.totalPages ?? 0 }, (_, i) => i + 1);
-        this.materialListSignal.set(response.data);
-      },
-      error: () => {
-        this.alertService.displayAlert(
-            'error',
-            'Error al obtener los materiales del curso.',
-            'center',
-            'top',
-            ['error-snackbar']
-        );
-      }
-    });
-  }
+    public totalItems: number[] = [];
 
-  getByTeacher(teacherId: number) {
-    this.setCurrentTeacherId(teacherId);
-    const params = {
-      page: this.search.page,
-      size: this.search.size,
-    };
+    private currentCourseId: number | null = null;
+    private currentTeacherId: number | null = null;
 
-    this.findAllWithParamsAndCustomSource(`teacher/${teacherId}/materials`, params).subscribe({
-      next: (response: IResponse<IMaterial[]>) => {
-        this.search = { ...this.search, ...response.meta };
-        this.totalItems = Array.from({ length: this.search.totalPages ?? 0 }, (_, i) => i + 1);
-        this.materialListSignal.set(response.data);
-      },
-      error: () => {
-        this.alertService.displayAlert(
-            'error',
-            'Error al obtener los materiales del profesor.',
-            'center',
-            'top',
-            ['error-snackbar']
-        );
-      }
-    });
-  }
+    get materials$() {
+        return this.materialListSignal;
+    }
 
-  save(material: IMaterial, courseId: number, teacherId: number) {
-    const customUrl = `course/${courseId}/teacher/${teacherId}`;
-    this.addCustomSource(customUrl, material).subscribe({
-      next: (response: IResponse<IMaterial>) => {
-        this.alertService.displayAlert(
-            'success',
-            response.message || 'Material creado correctamente.',
-            'center',
-            'top',
-            ['success-snackbar']
-        );
-        this.getByCourse(courseId);
-      },
-      error: () => {
-        this.alertService.displayAlert(
-            'error',
-            'Error al guardar el material.',
-            'center',
-            'top',
-            ['error-snackbar']
-        );
-      }
-    });
-  }
+    setCurrentCourseId(courseId: number | null) {
+        this.currentCourseId = courseId;
+    }
 
-  update(material: IMaterial, callback?: () => void) {
-    this.edit(material.id!, material).subscribe({
-      next: (response: IResponse<IMaterial>) => {
-        this.alertService.displayAlert(
-            'success',
-            response.message || 'Material actualizado correctamente.',
-            'center',
-            'top',
-            ['success-snackbar']
-        );
-        if (this.currentCourseId) {
-          this.getByCourse(this.currentCourseId);
-        }
-        if (callback) callback();
-      },
-      error: () => {
-        this.alertService.displayAlert(
-            'error',
-            'Error al actualizar el material.',
-            'center',
-            'top',
-            ['error-snackbar']
-        );
-      }
-    });
-  }
+    setCurrentTeacherId(teacherId: number | null) {
+        this.currentTeacherId = teacherId;
+    }
 
-  delete(material: IMaterial, callback?: () => void) {
-    this.del(material.id!).subscribe({
-      next: (response: IResponse<IMaterial>) => {
-        this.alertService.displayAlert(
-            'success',
-            response.message || 'Material eliminado correctamente.',
-            'center',
-            'top',
-            ['success-snackbar']
-        );
-        if (material.course?.id) {
-          this.getByCourse(material.course.id);
-        }
-        if (callback) callback();
-      },
-      error: () => {
-        this.alertService.displayAlert(
-            'error',
-            'Error al eliminar el material.',
-            'center',
-            'top',
-            ['error-snackbar']
-        );
-      }
-    });
-  }
+    getByCourse(courseId: number) {
+        this.setCurrentCourseId(courseId);
+        const params = {
+            page: this.search.page,
+            size: this.search.size,
+        };
+
+        this.findAllWithParamsAndCustomSource(`course/${courseId}/materials`, params).subscribe({
+            next: (response: IResponse<IMaterial[]>) => {
+                this.search = {...this.search, ...response.meta};
+                this.totalItems = Array.from({length: this.search.totalPages ?? 0}, (_, i) => i + 1);
+                this.materialListSignal.set(response.data);
+            },
+            error: () => {
+                this.alertService.displayAlert(
+                    'error',
+                    'Error al obtener los materiales del curso.',
+                    'center',
+                    'top',
+                    ['error-snackbar']
+                );
+            }
+        });
+    }
+
+    getByTeacher(teacherId: number) {
+        this.setCurrentTeacherId(teacherId);
+        const params = {
+            page: this.search.page,
+            size: this.search.size,
+        };
+
+        this.findAllWithParamsAndCustomSource(`teacher/${teacherId}/materials`, params).subscribe({
+            next: (response: IResponse<IMaterial[]>) => {
+                this.search = {...this.search, ...response.meta};
+                this.totalItems = Array.from({length: this.search.totalPages ?? 0}, (_, i) => i + 1);
+                this.materialListSignal.set(response.data);
+            },
+            error: () => {
+                this.alertService.displayAlert(
+                    'error',
+                    'Error al obtener los materiales del profesor.',
+                    'center',
+                    'top',
+                    ['error-snackbar']
+                );
+            }
+        });
+    }
+
+    save(material: IMaterial, courseId: number, teacherId: number) {
+        const customUrl = `course/${courseId}/teacher/${teacherId}`;
+        this.addCustomSource(customUrl, material).subscribe({
+            next: (response: IResponse<IMaterial>) => {
+                this.alertService.displayAlert(
+                    'success',
+                    response.message || 'Material creado correctamente.',
+                    'center',
+                    'top',
+                    ['success-snackbar']
+                );
+                this.getByCourse(courseId);
+            },
+            error: () => {
+                this.alertService.displayAlert(
+                    'error',
+                    'Error al guardar el material.',
+                    'center',
+                    'top',
+                    ['error-snackbar']
+                );
+            }
+        });
+    }
+
+    update(material: IMaterial, callback?: () => void) {
+        this.edit(material.id!, material).subscribe({
+            next: (response: IResponse<IMaterial>) => {
+                this.alertService.displayAlert(
+                    'success',
+                    response.message || 'Material actualizado correctamente.',
+                    'center',
+                    'top',
+                    ['success-snackbar']
+                );
+                if (this.currentCourseId) {
+                    this.getByCourse(this.currentCourseId);
+                }
+                if (callback) callback();
+            },
+            error: () => {
+                this.alertService.displayAlert(
+                    'error',
+                    'Error al actualizar el material.',
+                    'center',
+                    'top',
+                    ['error-snackbar']
+                );
+            }
+        });
+    }
+
+    delete(material: IMaterial, callback?: () => void) {
+        this.del(material.id!).subscribe({
+            next: (response: IResponse<IMaterial>) => {
+                this.alertService.displayAlert(
+                    'success',
+                    response.message || 'Material eliminado correctamente.',
+                    'center',
+                    'top',
+                    ['success-snackbar']
+                );
+                if (material.course?.id) {
+                    this.getByCourse(material.course.id);
+                }
+                if (callback) callback();
+            },
+            error: () => {
+                this.alertService.displayAlert(
+                    'error',
+                    'Error al eliminar el material.',
+                    'center',
+                    'top',
+                    ['error-snackbar']
+                );
+            }
+        });
+    }
 }

--- a/src/app/services/material.service.ts
+++ b/src/app/services/material.service.ts
@@ -1,0 +1,167 @@
+import { inject, Injectable, signal, WritableSignal } from '@angular/core';
+import { BaseService } from './base-service';
+import { AlertService } from './alert.service';
+import { IMaterial, ISearch, IResponse } from '../interfaces';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MaterialService extends BaseService<IMaterial> {
+  protected override source = 'materials';
+
+  private alertService = inject(AlertService);
+  private materialListSignal = signal<IMaterial[]>([]);
+
+  public search: ISearch = {
+    page: 1,
+    size: 5,
+    pageNumber: 1,
+    totalPages: 1,
+  };
+
+  public totalItems: number[] = [];
+
+  private currentCourseId: number | null = null;
+  private currentTeacherId: number | null = null;
+
+  get materials$() {
+    return this.materialListSignal;
+  }
+
+  setCurrentCourseId(courseId: number | null) {
+    this.currentCourseId = courseId;
+  }
+
+  setCurrentTeacherId(teacherId: number | null) {
+    this.currentTeacherId = teacherId;
+  }
+
+  getByCourse(courseId: number) {
+    this.setCurrentCourseId(courseId);
+    const params = {
+      page: this.search.page,
+      size: this.search.size,
+    };
+
+    this.findAllWithParamsAndCustomSource(`course/${courseId}/materials`, params).subscribe({
+      next: (response: IResponse<IMaterial[]>) => {
+        this.search = { ...this.search, ...response.meta };
+        this.totalItems = Array.from({ length: this.search.totalPages ?? 0 }, (_, i) => i + 1);
+        this.materialListSignal.set(response.data);
+      },
+      error: () => {
+        this.alertService.displayAlert(
+            'error',
+            'Error al obtener los materiales del curso.',
+            'center',
+            'top',
+            ['error-snackbar']
+        );
+      }
+    });
+  }
+
+  getByTeacher(teacherId: number) {
+    this.setCurrentTeacherId(teacherId);
+    const params = {
+      page: this.search.page,
+      size: this.search.size,
+    };
+
+    this.findAllWithParamsAndCustomSource(`teacher/${teacherId}/materials`, params).subscribe({
+      next: (response: IResponse<IMaterial[]>) => {
+        this.search = { ...this.search, ...response.meta };
+        this.totalItems = Array.from({ length: this.search.totalPages ?? 0 }, (_, i) => i + 1);
+        this.materialListSignal.set(response.data);
+      },
+      error: () => {
+        this.alertService.displayAlert(
+            'error',
+            'Error al obtener los materiales del profesor.',
+            'center',
+            'top',
+            ['error-snackbar']
+        );
+      }
+    });
+  }
+
+  save(material: IMaterial, courseId: number, teacherId: number) {
+    const customUrl = `course/${courseId}/teacher/${teacherId}`;
+    this.addCustomSource(customUrl, material).subscribe({
+      next: (response: IResponse<IMaterial>) => {
+        this.alertService.displayAlert(
+            'success',
+            response.message || 'Material creado correctamente.',
+            'center',
+            'top',
+            ['success-snackbar']
+        );
+        this.getByCourse(courseId);
+      },
+      error: () => {
+        this.alertService.displayAlert(
+            'error',
+            'Error al guardar el material.',
+            'center',
+            'top',
+            ['error-snackbar']
+        );
+      }
+    });
+  }
+
+  update(material: IMaterial, callback?: () => void) {
+    this.edit(material.id!, material).subscribe({
+      next: (response: IResponse<IMaterial>) => {
+        this.alertService.displayAlert(
+            'success',
+            response.message || 'Material actualizado correctamente.',
+            'center',
+            'top',
+            ['success-snackbar']
+        );
+        if (this.currentCourseId) {
+          this.getByCourse(this.currentCourseId);
+        }
+        if (callback) callback();
+      },
+      error: () => {
+        this.alertService.displayAlert(
+            'error',
+            'Error al actualizar el material.',
+            'center',
+            'top',
+            ['error-snackbar']
+        );
+      }
+    });
+  }
+
+  delete(material: IMaterial, callback?: () => void) {
+    this.del(material.id!).subscribe({
+      next: (response: IResponse<IMaterial>) => {
+        this.alertService.displayAlert(
+            'success',
+            response.message || 'Material eliminado correctamente.',
+            'center',
+            'top',
+            ['success-snackbar']
+        );
+        if (material.course?.id) {
+          this.getByCourse(material.course.id);
+        }
+        if (callback) callback();
+      },
+      error: () => {
+        this.alertService.displayAlert(
+            'error',
+            'Error al eliminar el material.',
+            'center',
+            'top',
+            ['error-snackbar']
+        );
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Description of the Change

This PR adds the full functionality for managing course materials. From the Courses page, the user can click **"View Materials"** to navigate to the Materials page filtered by the selected course. On the Materials page, users can **create**, **view**, **edit**, and **delete** materials associated with that course.

---

## What Was Done?

- [x] Added navigation from the Courses page to the Materials page using `queryParams` (e.g., `courseId`).
- [x] Created the Materials page with a list, pagination, and modal forms.
- [x] Implemented the Create, Read, Update, and Delete operations using the existing MaterialService.
- [x] Reused form and modal components for consistency across the app.
- [x] Integrated alert messages and loading states for better UX.

---

## How to Test It

1. Go to the Courses page.
2. Click on **"View Materials"** for a specific course.
3. On the Materials page:
   - Create a new material using the "Add" button.
   - Edit an existing material using the "Edit" icon.
   - Delete a material using the "Delete" icon and confirm the action.
4. Confirm that all actions reflect correctly in the UI and interact successfully with the backend.

---

## Related Issues

---

## Screenshots (Optional)

<img width="1782" height="613" alt="image" src="https://github.com/user-attachments/assets/f5d841b1-16e1-4766-858d-66f9773c28b8" />
<img width="1892" height="808" alt="image" src="https://github.com/user-attachments/assets/199b0b31-f93d-4573-9f1a-c70a4d05d79b" />

