### PR TITLE
Feature/materials view for student

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,45 +1,50 @@
-import { ApplicationConfig, importProvidersFrom } from "@angular/core";
-import { provideRouter } from "@angular/router";
+import {ApplicationConfig, importProvidersFrom, LOCALE_ID} from "@angular/core";
+import {provideRouter} from "@angular/router";
 
-import { routes } from "./app.routes";
-import { provideClientHydration } from "@angular/platform-browser";
-import { provideHttpClient, withInterceptors } from "@angular/common/http";
-import { baseUrlInterceptor } from "./interceptors/base-url.interceptor";
-import { accessTokenInterceptor } from "./interceptors/access-token.interceptor";
-import { handleErrorsInterceptor } from "./interceptors/handle-errors.interceptor";
-import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
+import {routes} from "./app.routes";
+import {provideClientHydration} from "@angular/platform-browser";
+import {provideHttpClient, withInterceptors} from "@angular/common/http";
+import {baseUrlInterceptor} from "./interceptors/base-url.interceptor";
+import {accessTokenInterceptor} from "./interceptors/access-token.interceptor";
+import {handleErrorsInterceptor} from "./interceptors/handle-errors.interceptor";
+import {provideAnimationsAsync} from "@angular/platform-browser/animations/async";
 import {
-  GoogleLoginProvider,
-  SocialAuthServiceConfig,
-  SocialLoginModule,
+    GoogleLoginProvider,
+    SocialAuthServiceConfig,
+    SocialLoginModule,
 } from "@abacritt/angularx-social-login";
 
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideRouter(routes),
-    provideClientHydration(),
-    provideHttpClient(
-        withInterceptors([
-          baseUrlInterceptor,
-          accessTokenInterceptor,
-        ])
-    ),
-    importProvidersFrom(SocialLoginModule),
-    {
-      provide: "SocialAuthServiceConfig",
-      useValue: {
-        autoLogin: false,
-        providers: [
-          {
-            id: GoogleLoginProvider.PROVIDER_ID,
-            provider: new GoogleLoginProvider(
-                "731369077540-79b1cu21reeiu3kv8647ej5jq601bcih.apps.googleusercontent.com"
-            ),
-          },
-        ],
-      } as SocialAuthServiceConfig,
-    },
-    provideAnimationsAsync(),
-  ],
-};
+import {registerLocaleData} from "@angular/common";
+import localeEs from "@angular/common/locales/es";
 
+registerLocaleData(localeEs);
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        provideRouter(routes),
+        provideClientHydration(),
+        provideHttpClient(
+            withInterceptors([
+                baseUrlInterceptor,
+                accessTokenInterceptor,
+            ])
+        ),
+        importProvidersFrom(SocialLoginModule),
+        {
+            provide: "SocialAuthServiceConfig",
+            useValue: {
+                autoLogin: false,
+                providers: [
+                    {
+                        id: GoogleLoginProvider.PROVIDER_ID,
+                        provider: new GoogleLoginProvider(
+                            "731369077540-79b1cu21reeiu3kv8647ej5jq601bcih.apps.googleusercontent.com"
+                        ),
+                    },
+                ],
+            } as SocialAuthServiceConfig,
+        },
+        provideAnimationsAsync(),
+        {provide: LOCALE_ID, useValue: 'es'}
+    ],
+};

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -29,6 +29,7 @@ import { StudentGroupsComponent } from "./pages/student-groups/student-groups.co
 import { GroupStoriesComponent } from "./pages/group-stories/group-stories.component";
 import { ChatComponent } from "./pages/chat/chat.component";
 import {MaterialsComponent} from "./pages/materials/materials.component";
+import {MaterialsReadOnlyComponent} from "./pages/materials-readonly/materials-readonly.component";
 
 export const routes: Routes = [
   {
@@ -245,6 +246,18 @@ export const routes: Routes = [
           name: "Materiales",
           showInSidebar: false,
         },
+
+      },
+      {
+        path: "materials-readonly",
+        component:MaterialsReadOnlyComponent,
+        canActivate: [StudentRoleGuard],
+        data: {
+          authorities: [IRoleType.student],
+          name: "Materiales",
+          showInSidebar: false,
+        },
+
       },
     ],
   },

--- a/src/app/components/courses/course-list/courses-list.component.html
+++ b/src/app/components/courses/course-list/courses-list.component.html
@@ -9,10 +9,10 @@
         </p>
         <div class="mb-4 mt-2">
             <input
-                    type="text"
+                    [(ngModel)]="searchText"
                     class="input-txt w-25"
                     placeholder="Filtrar cursos por código o título..."
-                    [(ngModel)]="searchText"
+                    type="text"
             />
         </div>
 
@@ -99,12 +99,12 @@
 
 <app-confirm-modal
     #confirmDeleteModal
+    (confirmed)="deleteConfirmation()"
+    [cancelText]="'Cancelar'"
+    [confirmText]="'Eliminar'"
     [message]="
     '¿Estás seguro de que deseas eliminar el curso ' + deleteCourse?.title + '?'
   "
-    [confirmText]="'Eliminar'"
-    [cancelText]="'Cancelar'"
-    (confirmed)="deleteConfirmation()"
 >
 </app-confirm-modal>
 

--- a/src/app/components/courses/course-list/courses-list.component.ts
+++ b/src/app/components/courses/course-list/courses-list.component.ts
@@ -2,52 +2,52 @@ import {Component, EventEmitter, Input, Output, ViewChild} from '@angular/core';
 import {ICourse} from "../../../interfaces";
 import {ConfirmModalComponent} from "../../confirm-modal/confirm-modal.component";
 import {DatePipe} from "@angular/common";
-import {RouterLink, RouterModule} from "@angular/router";
+import {RouterModule} from "@angular/router";
 import {FormsModule} from '@angular/forms';
 
 @Component({
-  selector: 'app-courses-list',
-  standalone: true,
-  imports: [
-    ConfirmModalComponent,
-    DatePipe,
-    RouterModule,
-    FormsModule
-  ],
-  templateUrl: './courses-list.component.html',
-  styleUrl: './courses-list.component.scss'
+    selector: 'app-courses-list',
+    standalone: true,
+    imports: [
+        ConfirmModalComponent,
+        DatePipe,
+        RouterModule,
+        FormsModule
+    ],
+    templateUrl: './courses-list.component.html',
+    styleUrl: './courses-list.component.scss'
 })
 export class CoursesListComponent {
-  @Input() courses: ICourse[] = [];
-  @Output() callUpdateModalMethod: EventEmitter<ICourse> = new EventEmitter<ICourse>();
-  @Output() callDeleteAction = new EventEmitter<ICourse>();
-  @Output() callModalAction = new EventEmitter<ICourse>();
+    @Input() courses: ICourse[] = [];
+    @Output() callUpdateModalMethod: EventEmitter<ICourse> = new EventEmitter<ICourse>();
+    @Output() callDeleteAction = new EventEmitter<ICourse>();
+    @Output() callModalAction = new EventEmitter<ICourse>();
 
-  deleteCourse: ICourse | null = null;
-  searchText: string = '';
+    deleteCourse: ICourse | null = null;
+    searchText: string = '';
 
-  @ViewChild('confirmDeleteModal') confirmDeleteModal!: ConfirmModalComponent;
+    @ViewChild('confirmDeleteModal') confirmDeleteModal!: ConfirmModalComponent;
 
-  
-  get filteredCourses(): ICourse[] {
-  if (!this.searchText) return this.courses;
-  const lower = this.searchText.toLowerCase();
-  return this.courses.filter(course =>
-    (course.code?.toLowerCase() ?? '').includes(lower) ||
-    (course.title?.toLowerCase()?? '').includes(lower)
-  );
-}
 
-  openConfirmationModal(course: ICourse): void {
-    this.deleteCourse = course;
-    this.confirmDeleteModal.show();
-  }
-
-  deleteConfirmation(): void {
-    if (this.deleteCourse) {
-      this.callDeleteAction.emit(this.deleteCourse);
-      this.deleteCourse = null;
+    get filteredCourses(): ICourse[] {
+        if (!this.searchText) return this.courses;
+        const lower = this.searchText.toLowerCase();
+        return this.courses.filter(course =>
+            (course.code?.toLowerCase() ?? '').includes(lower) ||
+            (course.title?.toLowerCase() ?? '').includes(lower)
+        );
     }
-  }
+
+    openConfirmationModal(course: ICourse): void {
+        this.deleteCourse = course;
+        this.confirmDeleteModal.show();
+    }
+
+    deleteConfirmation(): void {
+        if (this.deleteCourse) {
+            this.callDeleteAction.emit(this.deleteCourse);
+            this.deleteCourse = null;
+        }
+    }
 
 }

--- a/src/app/components/student-groups/student-groups-list/student-groups-list.component.html
+++ b/src/app/components/student-groups/student-groups-list/student-groups-list.component.html
@@ -9,48 +9,59 @@
 
         <div class="mb-4 mt-2">
             <input type="text" class="input-txt input-filter"
-                placeholder="Filtrar grupos por nombre, curso o docente..." [(ngModel)]="searchText" />
+                   placeholder="Filtrar grupos por nombre, curso o docente..." [(ngModel)]="searchText"/>
         </div>
 
         <div class="table-container table-responsive">
             <table class="table custom-full-bordered-table">
                 <thead class="table-header-gray">
-                    <tr>
-                        <th scope="col">Nombre del Grupo</th>
-                        <th scope="col">Docente</th>
-                        <th scope="col">Curso</th>
-                        <th class="text-center" scope="col">Ver curso</th>
-                    </tr>
+                <tr>
+                    <th scope="col">Nombre del Grupo</th>
+                    <th scope="col">Docente</th>
+                    <th scope="col">Curso</th>
+                    <th class="text-center" scope="col">Acciones</th>
+                </tr>
                 </thead>
                 <tbody>
                     @for (item of filteredGroups; track item.id) {
-                    <tr>
-                        <td>{{ item.name }}</td>
-                        <td>{{ item.teacher?.name }} {{ item.teacher?.lastname }}</td>
-                        <td>{{ item.course?.title }}</td>
-                        <td class="text-center">
-                            <!-- Botón ver historias del grupo -->
-                            <button (click)="groupClick.emit(item.id!)" class="btn btn-view border-0 icon-gray-color"
-                                    type="button" title="Ver historias del grupo" style="cursor: pointer;">
-                                <i class="fas fa-eye"></i>
-                            </button>
+                        <tr>
+                            <td>{{ item.name }}</td>
+                            <td>{{ item.teacher?.name }} {{ item.teacher?.lastname }}</td>
+                            <td>{{ item.course?.title }}</td>
+                            <td class="text-center">
+                                <div class="d-flex justify-content-center gap-3">
+          <span
+                  (click)="groupClick.emit(item.id!)"
+                  role="button"
+                  tabindex="0"
+                  title="Ver Historias"
+                  class="no-link-style text-link-special"
+                  style="cursor: pointer;"
+          >
+            <i class="fas fa-book-open me-2"></i> Ver Historias
+          </span>
 
-                            <!-- Nuevo botón para ver materiales del curso -->
-                            <button (click)="goToMaterials(item.course?.id!)" class="btn btn-view border-0 icon-gray-color ms-2"
-                                    type="button" title="Ver materiales del curso" style="cursor: pointer;">
-                                <i class="fas fa-book-open"></i>
-                            </button>
-                        </td>
-
-                    </tr>
+                                    <span
+                                            (click)="goToMaterials(item.course?.id!)"
+                                            role="button"
+                                            tabindex="0"
+                                            title="Ver Materiales"
+                                            class="no-link-style text-link-special"
+                                            style="cursor: pointer;"
+                                    >
+            <i class="fas fa-folder-open me-2"></i> Ver Materiales
+          </span>
+                                </div>
+                            </td>
+                        </tr>
                     } @empty {
-                    <tr>
-                        <td colspan="4">
-                            <div class="d-flex justify-content-center align-items-center w-100">
-                                <p class="mb-0">No hay grupos asignados</p>
-                            </div>
-                        </td>
-                    </tr>
+                        <tr>
+                            <td colspan="4">
+                                <div class="d-flex justify-content-center align-items-center w-100">
+                                    <p class="mb-0">No hay grupos asignados</p>
+                                </div>
+                            </td>
+                        </tr>
                     }
                 </tbody>
             </table>

--- a/src/app/components/student-groups/student-groups-list/student-groups-list.component.html
+++ b/src/app/components/student-groups/student-groups-list/student-groups-list.component.html
@@ -29,11 +29,19 @@
                         <td>{{ item.teacher?.name }} {{ item.teacher?.lastname }}</td>
                         <td>{{ item.course?.title }}</td>
                         <td class="text-center">
+                            <!-- Botón ver historias del grupo -->
                             <button (click)="groupClick.emit(item.id!)" class="btn btn-view border-0 icon-gray-color"
-                                type="button" title="Ver historias del grupo" style="cursor: pointer;">
+                                    type="button" title="Ver historias del grupo" style="cursor: pointer;">
                                 <i class="fas fa-eye"></i>
                             </button>
+
+                            <!-- Nuevo botón para ver materiales del curso -->
+                            <button (click)="goToMaterials(item.course?.id!)" class="btn btn-view border-0 icon-gray-color ms-2"
+                                    type="button" title="Ver materiales del curso" style="cursor: pointer;">
+                                <i class="fas fa-book-open"></i>
+                            </button>
                         </td>
+
                     </tr>
                     } @empty {
                     <tr>

--- a/src/app/components/student-groups/student-groups-list/student-groups-list.component.html
+++ b/src/app/components/student-groups/student-groups-list/student-groups-list.component.html
@@ -1,70 +1,51 @@
-<div class="card">
+<div class="card card-with-grid">
     <div class="card-header card-header-indigo">
-        <h2 class="mb-0">Lista de Grupos</h2>
+        <h2 class="mb-0 title-highlight">Mis Grupos</h2>
     </div>
+
     <div class="card-body">
-        <p class="text-muted mb-3">
-            Lista de grupos a los que está asignado el estudiante. Selecciona un grupo para ver sus historias.
+        <p class="text-muted mb-3 fs-5">
+            Aquí puedes ver todos los grupos a los que perteneces. En cada tarjeta encontrarás detalles del curso y el docente a cargo, además de enlaces directos a sus materiales e historias.
         </p>
 
         <div class="mb-4 mt-2">
-            <input type="text" class="input-txt input-filter"
-                   placeholder="Filtrar grupos por nombre, curso o docente..." [(ngModel)]="searchText"/>
+            <input
+                    type="text"
+                    class="input-txt input-filter"
+                    placeholder="Filtrar grupos por nombre, curso o docente..."
+                    [(ngModel)]="searchText"
+            />
         </div>
 
-        <div class="table-container table-responsive">
-            <table class="table custom-full-bordered-table">
-                <thead class="table-header-gray">
-                <tr>
-                    <th scope="col">Nombre del Grupo</th>
-                    <th scope="col">Docente</th>
-                    <th scope="col">Curso</th>
-                    <th class="text-center" scope="col">Acciones</th>
-                </tr>
-                </thead>
-                <tbody>
-                    @for (item of filteredGroups; track item.id) {
-                        <tr>
-                            <td>{{ item.name }}</td>
-                            <td>{{ item.teacher?.name }} {{ item.teacher?.lastname }}</td>
-                            <td>{{ item.course?.title }}</td>
-                            <td class="text-center">
-                                <div class="d-flex justify-content-center gap-3">
-          <span
-                  (click)="groupClick.emit(item.id!)"
-                  role="button"
-                  tabindex="0"
-                  title="Ver Historias"
-                  class="no-link-style text-link-special"
-                  style="cursor: pointer;"
-          >
-            <i class="fas fa-book-open me-2"></i> Ver Historias
-          </span>
+        <div class="groups-grid">
+            @for (item of filteredGroups; track item.id) {
+                <div class="group-card" role="button" tabindex="0">
+                    <div class="group-card-header">
+                        <h3 class="group-title mb-1">{{ item.name }}</h3>
+                        <span class="badge-course">{{ item.course?.title }}</span>
+                    </div>
 
-                                    <span
-                                            (click)="goToMaterials(item.course?.id!)"
-                                            role="button"
-                                            tabindex="0"
-                                            title="Ver Materiales"
-                                            class="no-link-style text-link-special"
-                                            style="cursor: pointer;"
-                                    >
-            <i class="fas fa-folder-open me-2"></i> Ver Materiales
-          </span>
-                                </div>
-                            </td>
-                        </tr>
-                    } @empty {
-                        <tr>
-                            <td colspan="4">
-                                <div class="d-flex justify-content-center align-items-center w-100">
-                                    <p class="mb-0">No hay grupos asignados</p>
-                                </div>
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
+                    <div class="group-card-body">
+                        <div class="group-detail">
+                            <i class="fas fa-user-tie me-2"></i>
+                            <span><strong>Docente:</strong> {{ item.teacher?.name }} {{ item.teacher?.lastname }}</span>
+                        </div>
+                    </div>
+
+                    <div class="group-card-footer">
+                        <button class="btn btn-link-action" (click)="groupClick.emit(item.id!)" title="Ver Historias">
+                            <i class="fas fa-book-open me-2"></i>Historias
+                        </button>
+                        <button class="btn btn-link-action" (click)="goToMaterials(item.course?.id!)" title="Ver Materiales">
+                            <i class="fas fa-folder-open me-2"></i>Materiales
+                        </button>
+                    </div>
+                </div>
+            } @empty {
+                <div class="empty-state">
+                    <p class="mb-0">No hay grupos asignados aún. ¡Explora y únete cuando estés listo!</p>
+                </div>
+            }
         </div>
     </div>
 </div>

--- a/src/app/components/student-groups/student-groups-list/student-groups-list.component.scss
+++ b/src/app/components/student-groups/student-groups-list/student-groups-list.component.scss
@@ -1,19 +1,134 @@
-.no-link-style {
-  text-decoration: none;
+.groups-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  padding: 10px 0;
+}
+
+.group-card {
+  background: #fff;
+  border: 1px solid var(--color-gray-border);
+  border-radius: 16px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  cursor: pointer;
+  outline-offset: 4px;
+}
+
+.group-card:hover,
+.group-card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.18);
+  outline: none;
+}
+
+.group-card:focus-visible {
+  outline: 3px solid var(--color-blue-munsell);
+}
+
+.group-card-header {
+  background-color: var(--color-gray-light);
+  padding: 20px;
+  border-bottom: 1px solid var(--color-gray-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.group-title {
+  font-size: 1.4rem;
+  font-weight: 700;
   color: var(--color-indigo-dye);
-  transition: color 0.2s ease-in-out;
+  margin: 0;
+  flex: 1;
 }
 
-.no-link-style:hover {
+.badge-course {
+  background-color: var(--color-blue-munsell);
+  color: #fff;
+  font-size: 0.85rem;
+  padding: 6px 14px;
+  border-radius: 50px;
+  box-shadow: 0 2px 8px rgb(0 161 224 / 0.4);
+  font-weight: 600;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.group-card-body {
+  padding: 20px;
+  font-size: 1rem;
+  color: var(--color-indigo-dye);
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+}
+
+.group-detail {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  color: #444;
+}
+
+.group-detail i {
   color: var(--color-blue-munsell);
+  font-size: 1.2rem;
 }
 
-.text-link-special {
-  color: var(--color-blue-munsell) !important;
-  font-weight: 500;
-  text-decoration: none;
+.group-card-footer {
+  border-top: 1px solid var(--color-gray-border);
+  padding: 16px 24px;
+  background-color: #f9fbfc;
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
 }
 
-.text-link-special:hover {
-  color: var(--color-indigo-dye) !important;
+.btn-link-action {
+  background: none;
+  border: none;
+  color: var(--color-blue-munsell);
+  font-weight: 600;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 8px;
+  transition: background-color 0.25s ease, color 0.25s ease, transform 0.1s ease;
+}
+
+.btn-link-action:hover,
+.btn-link-action:focus-visible {
+  background-color: var(--color-blue-munsell);
+  color: #fff;
+  outline: none;
+  transform: scale(1.05);
+  box-shadow: 0 2px 8px rgb(0 161 224 / 0.6);
+}
+
+.btn-link-action i {
+  transition: transform 0.3s ease;
+}
+
+.btn-link-action:hover i,
+.btn-link-action:focus-visible i {
+  transform: translateX(4px);
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 50px 20px;
+  color: var(--color-indigo-dye);
+  background-color: var(--color-gray-light);
+  border-radius: 16px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  user-select: none;
 }

--- a/src/app/components/student-groups/student-groups-list/student-groups-list.component.scss
+++ b/src/app/components/student-groups/student-groups-list/student-groups-list.component.scss
@@ -1,12 +1,19 @@
 .no-link-style {
   text-decoration: none;
-  color: inherit;
-  cursor: pointer;
+  color: var(--color-indigo-dye);
+  transition: color 0.2s ease-in-out;
 }
 
 .no-link-style:hover {
-  color: #007bff;
-} 
-.btn-view {
-  cursor: pointer;
+  color: var(--color-blue-munsell);
+}
+
+.text-link-special {
+  color: var(--color-blue-munsell) !important;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.text-link-special:hover {
+  color: var(--color-indigo-dye) !important;
 }

--- a/src/app/components/student-groups/student-groups-list/student-groups-list.component.ts
+++ b/src/app/components/student-groups/student-groups-list/student-groups-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IGroup } from '../../../interfaces';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 
 @Component({
     selector: 'app-student-groups-list',
@@ -17,6 +18,9 @@ export class StudentGroupsListComponent {
 
     searchText: string = '';
 
+    constructor(private router: Router) {}
+
+
     get filteredGroups(): IGroup[] {
         if (!this.searchText) return this.groups;
         const lower = this.searchText.toLowerCase();
@@ -26,4 +30,10 @@ export class StudentGroupsListComponent {
             (g.teacher?.name?.toLowerCase() ?? '').includes(lower)
         );
     }
-} 
+
+    goToMaterials(courseId: number) {
+        this.router.navigate(['/app/materials-readonly'], {
+            queryParams: { courseId }
+        });
+    }
+}

--- a/src/app/pages/materials-readonly/materials-readonly.component.html
+++ b/src/app/pages/materials-readonly/materials-readonly.component.html
@@ -1,0 +1,63 @@
+<div class="row p-4">
+    <div class="col-12 mb-3">
+        <h2 class="title-highlight mb-2">¡Prepárate para aprender!</h2>
+        <div class="mt-2">
+            <button (click)="goBack()" class="btn btn-custom-volver">
+                <i class="fas fa-arrow-left me-2"></i> Volver
+            </button>
+        </div>
+    </div>
+
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header card-header-indigo">
+                <h2 class="mb-0">Recursos esenciales para tu curso</h2>
+            </div>
+            <div class="card-body">
+                <p class="mb-4">
+                    Aquí encontrarás todos los materiales que necesitas para dominar este curso. Explora los recursos y lleva tu aprendizaje al siguiente nivel.
+                </p>
+
+                <div class="mb-4 mt-2">
+                    <input
+                            [(ngModel)]="searchText"
+                            class="form-control input-filter"
+                            placeholder="Encuentra un material rápidamente..."
+                            type="text"
+                    />
+                </div>
+
+                <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+                    <div class="col" *ngFor="let material of filteredMaterials()">
+                        <div class="card h-100 material-card" [ngClass]="getFileColorClass(material.fileUrl)">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex align-items-start mb-3">
+                                    <i
+                                            class="me-3 file-icon"
+                                            [ngClass]="[getFileIcon(material.fileUrl), getFileColorClass(material.fileUrl) + '-icon']"
+                                    ></i>
+                                    <div class="flex-grow-1">
+                                        <h5 class="card-title mb-1">{{ material.name }}</h5>
+                                        <small class="text-muted">Subido por {{ material.teacher?.name || 'Profesor sin asignar' }}</small><br />
+                                        <small class="text-muted">Fecha: {{ material.uploadedAt | date: 'longDate':'':'es' }}</small>
+                                    </div>
+                                </div>
+                                <div class="mt-auto d-grid gap-2">
+                                    <a [href]="material.fileUrl" target="_blank" rel="noopener noreferrer" class="btn btn-primary">
+                                        <i class="fas fa-eye me-2"></i> Ver Material
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-12" *ngIf="filteredMaterials().length === 0">
+                        <div class="alert alert-info text-center" role="alert">
+                            No hay materiales disponibles en este momento. ¡Sigue revisando las actualizaciones!
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/pages/materials-readonly/materials-readonly.component.scss
+++ b/src/app/pages/materials-readonly/materials-readonly.component.scss
@@ -1,0 +1,108 @@
+.no-link-style {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.no-link-style:hover {
+  color: #007bff;
+}
+
+.link-material {
+  color: var(--color-indigo-dye);
+  text-decoration: none;
+  transition: color 0.2s ease-in-out;
+}
+
+.link-material:hover {
+  color: var(--color-blue-munsell);
+}
+
+.link-material i {
+  color: var(--color-blue-munsell);
+  transition: color 0.2s ease-in-out;
+}
+
+.link-material:hover i {
+  color: var(--color-indigo-dye);
+}
+
+.material-card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border-radius: 12px;
+  overflow: hidden;
+  border: none;
+}
+
+.material-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+.file-icon {
+  font-size: 3em !important;
+  min-width: 40px;
+  text-align: center;
+}
+
+.card-title {
+  font-size: var(--font-h3-size, 1.5rem);
+  font-weight: var(--font-h3-weight, 600);
+  color: var(--color-indigo-dye, #3f51b5);
+}
+
+/* Colores según tipo de archivo */
+.material-card.color-pdf {
+  border-left: 5px solid #d9534f;
+}
+
+.material-card.color-word {
+  border-left: 5px solid #2864b4;
+}
+
+.material-card.color-excel {
+  border-left: 5px solid #3c763d;
+}
+
+.material-card.color-powerpoint {
+  border-left: 5px solid #d45915;
+}
+
+.material-card.color-default {
+  border-left: 5px solid var(--color-indigo-dye, #3f51b5);
+}
+
+.color-pdf-icon {
+  color: #d9534f !important;
+}
+
+.color-word-icon {
+  color: #2864b4 !important;
+}
+
+.color-excel-icon {
+  color: #3c763d !important;
+}
+
+.color-powerpoint-icon {
+  color: #d45915 !important;
+}
+
+.color-default-icon {
+  color: var(--color-indigo-dye, #3f51b5) !important;
+}
+
+.btn-custom-volver {
+  background-color: #003E6B;
+  color: #fff;
+  border: 1px solid #003E6B;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+  font-weight: bold;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+

--- a/src/app/pages/materials-readonly/materials-readonly.component.scss
+++ b/src/app/pages/materials-readonly/materials-readonly.component.scss
@@ -51,7 +51,6 @@
   color: var(--color-indigo-dye, #3f51b5);
 }
 
-/* Colores según tipo de archivo */
 .material-card.color-pdf {
   border-left: 5px solid #d9534f;
 }

--- a/src/app/pages/materials-readonly/materials-readonly.component.ts
+++ b/src/app/pages/materials-readonly/materials-readonly.component.ts
@@ -37,8 +37,16 @@ export class MaterialsReadOnlyComponent implements OnInit {
 
     filteredMaterials(): IMaterial[] {
         if (!this.searchText) return this.materials();
+
         const lower = this.searchText.toLowerCase();
-        return this.materials().filter(m => m.name.toLowerCase().includes(lower));
+
+        return this.materials().filter(material =>
+            material.name?.toLowerCase().includes(lower) ||
+            material.teacher?.name?.toLowerCase().includes(lower) ||
+            material.fileUrl?.toLowerCase().includes(lower) ||
+            this.getFileExtension(material.fileUrl)?.includes(lower) ||
+            (material.uploadedAt && new Date(material.uploadedAt).toLocaleDateString('es-ES').includes(lower))
+        );
     }
 
     getFileIcon(fileUrl: string): string {

--- a/src/app/pages/materials-readonly/materials-readonly.component.ts
+++ b/src/app/pages/materials-readonly/materials-readonly.component.ts
@@ -1,0 +1,90 @@
+import {Component, OnInit, inject} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {CommonModule, Location} from '@angular/common';
+import {MaterialService} from '../../services/material.service';
+import {IMaterial} from '../../interfaces';
+import {FormsModule} from "@angular/forms";
+
+@Component({
+    selector: 'app-materials-readonly',
+    standalone: true,
+    imports: [CommonModule, FormsModule],
+    templateUrl: './materials-readonly.component.html',
+    styleUrls: ['./materials-readonly.component.scss']
+})
+export class MaterialsReadOnlyComponent implements OnInit {
+    private route = inject(ActivatedRoute);
+    private materialService = inject(MaterialService);
+    private location = inject(Location);
+    public materials = this.materialService.materials$;
+    public searchText = '';
+    private courseId: number | null = null;
+
+    ngOnInit(): void {
+        this.route.queryParams.subscribe(params => {
+            const id = Number(params['courseId']);
+            if (id) {
+                this.courseId = id;
+                this.materialService.setCurrentCourseId(id);
+                this.materialService.getByCourse(id);
+            }
+        });
+    }
+
+    goBack() {
+        this.location.back();
+    }
+
+    filteredMaterials(): IMaterial[] {
+        if (!this.searchText) return this.materials();
+        const lower = this.searchText.toLowerCase();
+        return this.materials().filter(m => m.name.toLowerCase().includes(lower));
+    }
+
+    getFileIcon(fileUrl: string): string {
+        const ext = this.getFileExtension(fileUrl);
+        switch (ext) {
+            case 'pdf':
+                return 'fas fa-file-pdf';
+            case 'doc':
+            case 'docx':
+                return 'fas fa-file-word';
+            case 'xls':
+            case 'xlsx':
+                return 'fas fa-file-excel';
+            case 'ppt':
+            case 'pptx':
+                return 'fas fa-file-powerpoint';
+            case 'txt':
+                return 'fas fa-file-alt';
+            case 'zip':
+            case 'rar':
+                return 'fas fa-file-archive';
+            default:
+                return 'fas fa-file';
+        }
+    }
+
+    getFileColorClass(fileUrl: string): string {
+        const ext = this.getFileExtension(fileUrl);
+        switch (ext) {
+            case 'pdf':
+                return 'color-pdf';
+            case 'doc':
+            case 'docx':
+                return 'color-word';
+            case 'xls':
+            case 'xlsx':
+                return 'color-excel';
+            case 'ppt':
+            case 'pptx':
+                return 'color-powerpoint';
+            default:
+                return 'color-default';
+        }
+    }
+
+    private getFileExtension(fileUrl: string): string | undefined {
+        return fileUrl.split('.').pop()?.toLowerCase();
+    }
+}

--- a/src/app/pages/student-groups/student-groups.component.html
+++ b/src/app/pages/student-groups/student-groups.component.html
@@ -1,24 +1,26 @@
 <div class="row p-4">
-    <div class="col-12 mb-3">
-        <h2 class="title-highlight">Grupos del Estudiante</h2>
-    </div>
-    <div class="col-12">
-        <div class="d-flex justify-content-between align-items-center">
-            <button (click)="goBack()" type="button" class="btn custom-add-full-btn">
-                <i class="fas fa-arrow-left me-2"></i> Volver
-            </button>
-        </div>
+    <div class="col-12 mb-4">
+        <h1 class="title-highlight display-5 fw-bold">Grupos del Estudiante</h1>
     </div>
 
-    <div class="col-12 mt-3">
-        <div class="card">
+    <div class="col-12 mb-4 d-flex justify-content-start">
+        <button (click)="goBack()" type="button" class="btn btn-primary btn-lg custom-btn-back">
+            <i class="fas fa-arrow-left me-2"></i> Volver
+        </button>
+    </div>
+
+    <div class="col-12">
+        <div class="card shadow-sm rounded-4">
             <div class="card-body">
-                <app-student-groups-list [groups]="studentGroupsService.groups$()"
-                    (groupClick)="goToGroupStories($event)">
+                <app-student-groups-list
+                        [groups]="studentGroupsService.groups$()"
+                        (groupClick)="goToGroupStories($event)">
                 </app-student-groups-list>
 
-                <app-pagination *ngIf="studentGroupsService.groups$().length > 0"
-                    [service]="studentGroupsService.search" [loadFunction]="loadGroups.bind(this)">
+                <app-pagination
+                        *ngIf="studentGroupsService.groups$().length > 0"
+                        [service]="studentGroupsService.search"
+                        [loadFunction]="loadGroups.bind(this)">
                 </app-pagination>
             </div>
         </div>

--- a/src/app/pages/student-groups/student-groups.component.scss
+++ b/src/app/pages/student-groups/student-groups.component.scss
@@ -1,44 +1,64 @@
+
 .custom-add-full-btn {
   background-color: #003E6B;
   color: #fff;
   border: 1px solid #003E6B;
   padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem;
-  transition: background-color 0.3s ease, border-color 0.3s ease;
-  font-weight: bold;
+  border-radius: 0.6rem;
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  font-weight: 700;
   text-transform: uppercase;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  user-select: none;
 }
 
-.custom-add-full-btn:hover {
+.custom-add-full-btn:hover,
+.custom-add-full-btn:focus {
   background-color: #002e50;
   border-color: #002e50;
-}
-
-.custom-add-full-btn:focus {
-  box-shadow: 0 0 0 0.25rem rgba(0, 62, 107, 0.5);
+  box-shadow: 0 0 8px rgba(0, 46, 80, 0.6);
+  outline: none;
+  color: #fff;
 }
 
 .custom-full-bordered-table {
   border-collapse: separate;
   border-spacing: 0;
   border: 1px solid #e9ecef;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  width: 100%;
+  background-color: #fff;
+  box-shadow: 0 2px 6px rgb(0 0 0 / 0.05);
 }
 
 .custom-full-bordered-table thead th {
   border-bottom: 1px solid #e9ecef;
   border-right: 1px solid #e9ecef;
   color: #495057;
+  background-color: #f8f9fa;
+  font-weight: 600;
+  padding: 12px 15px;
+  text-align: left;
+  user-select: none;
 }
 
 .custom-full-bordered-table thead th:last-child {
   border-right: none;
 }
 
-.table-header-gray {
-  background-color: #f8f9fa;
+.custom-full-bordered-table tbody tr {
+  transition: background-color 0.2s ease;
+  cursor: pointer;
+}
+
+.custom-full-bordered-table tbody tr:hover {
+  background-color: #f1f5f9;
 }
 
 .custom-full-bordered-table tbody tr td,
@@ -46,6 +66,7 @@
   color: #212529;
   border-bottom: 1px solid #e9ecef;
   border-right: 1px solid #e9ecef;
+  padding: 12px 15px;
 }
 
 .custom-full-bordered-table tbody tr:last-child td,
@@ -64,6 +85,8 @@
 
 .icon-gray-color {
   color: #6c757d;
+  transition: color 0.2s ease;
+  cursor: pointer;
 }
 
 .icon-gray-color:hover {

--- a/src/app/services/student-groups.service.ts
+++ b/src/app/services/student-groups.service.ts
@@ -38,6 +38,7 @@ export class StudentGroupsService extends BaseService<IGroup> {
         this.findAllWithParamsAndCustomSource(`student/${studentId}/groups`, params).subscribe({
             next: (response: IResponse<IGroup[]>) => {
                 this.groupListSignal.set(response.data);
+                console.log(response.data);
                 this.search = { ...this.search, ...response.meta };
                 this.totalItems = Array.from(
                     { length: this.search.totalPages || 0 },

--- a/src/app/services/student-groups.service.ts
+++ b/src/app/services/student-groups.service.ts
@@ -38,7 +38,6 @@ export class StudentGroupsService extends BaseService<IGroup> {
         this.findAllWithParamsAndCustomSource(`student/${studentId}/groups`, params).subscribe({
             next: (response: IResponse<IGroup[]>) => {
                 this.groupListSignal.set(response.data);
-                console.log(response.data);
                 this.search = { ...this.search, ...response.meta };
                 this.totalItems = Array.from(
                     { length: this.search.totalPages || 0 },

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,4 +3,4 @@ import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
 bootstrapApplication(AppComponent, appConfig)
-  .catch((err) => console.error(err));
+    .catch((err) => console.error(err));


### PR DESCRIPTION
## Description of the Change

A new page called **material-readonly** was created for students, displaying a list of materials in read-only mode without options to edit or delete.  
Additionally, the styles for the groups section were modified to better fit the student view, enhancing the visual design and usability of the groups component.

---

## What Was Done?

- [x] Created the `material-readonly` component and page to show materials in read-only mode for students.  
- [x] Adjusted and refactored the CSS styles for the groups view for students, improving design, accessibility, and responsiveness.  
- [x] Removed buttons and actions not applicable to students from the groups and materials views.

---

## How to Test It

1. Log in as a student user.  
2. Navigate to the `material-readonly` page.  
3. Verify that only the list of materials is displayed, without options to add, edit, or delete.  
4. Access the groups view and confirm the updated styles and that only permitted actions are shown for the student.  
5. Test filtering and navigation on both pages to ensure correct functionality.

---

## Related Issues

- Closes # (insert issue number if applicable)  
- Related to # (insert related issue number if applicable)  

---

## Screenshots (Optional)
<img width="1903" height="930" alt="image" src="https://github.com/user-attachments/assets/dfe0be26-f41e-484e-a8be-22d3d4fa7979" />
<img width="1913" height="945" alt="image" src="https://github.com/user-attachments/assets/2fcb4966-44b4-4a78-8995-9efaec4941f1" />

